### PR TITLE
Integrate AI content creation option

### DIFF
--- a/perch/addons/apps/perch_blog/ai/generate.php
+++ b/perch/addons/apps/perch_blog/ai/generate.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/../lib/PerchBlog_AI.class.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+$prompt = isset($input['prompt']) ? $input['prompt'] : '';
+
+$ai = new PerchBlog_AI();
+$content = $ai->generate($prompt);
+
+echo json_encode(['content' => $content]);
+?>

--- a/perch/addons/apps/perch_blog/lib/PerchBlog_AI.class.php
+++ b/perch/addons/apps/perch_blog/lib/PerchBlog_AI.class.php
@@ -1,0 +1,45 @@
+<?php
+class PerchBlog_AI
+{
+    private $api_key;
+
+    public function __construct()
+    {
+        $this->api_key = getenv('OPENAI_API_KEY');
+    }
+
+    public function generate($prompt)
+    {
+        if (!$this->api_key) {
+            return 'OpenAI API key is not set.';
+        }
+
+        $ch = curl_init('https://api.openai.com/v1/completions');
+        $data = [
+            'model' => 'text-davinci-003',
+            'prompt' => $prompt,
+            'max_tokens' => 150,
+        ];
+
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . $this->api_key,
+        ]);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+
+        $response = curl_exec($ch);
+        if ($response === false) {
+            return 'Failed to contact AI service.';
+        }
+
+        $resp = json_decode($response, true);
+        if (isset($resp['choices'][0]['text'])) {
+            return trim($resp['choices'][0]['text']);
+        }
+
+        return 'No content generated.';
+    }
+}
+?>

--- a/perch/addons/apps/perch_blog/modes/edit.post.php
+++ b/perch/addons/apps/perch_blog/modes/edit.post.php
@@ -106,19 +106,38 @@
                 if ($CurrentUser->has_priv('perch_blog.post.publish')) $opts[] = array('label'=>$Lang->get('Published'), 'value'=>'Published');
                 echo $Form->select_field('postStatus', 'Status', $opts, isset($details['postStatus'])?$details['postStatus']:'Draft');
 
-                echo $Form->submit_field('btnSubmit', 'Save', $API->app_path());
+                $ai_button = '<button type="button" id="btnGenerateAI" class="button button-simple">'.PerchUtil::html($Lang->get('Generate with AI')).'</button>';
+                echo $Form->submit_field('btnSubmit', 'Save', $API->app_path(), 'button', $ai_button);
 
             } else {
 
                 echo $Form->hidden('authorID', $Author->id());
                 echo $Form->hidden('postStatus', 'Draft');
-                echo $Form->submit_field('btnSubmit', 'Create draft', $API->app_path());
+                $ai_button = '<button type="button" id="btnGenerateAI" class="button button-simple">'.PerchUtil::html($Lang->get('Generate with AI')).'</button>';
+                echo $Form->submit_field('btnSubmit', 'Create draft', $API->app_path(), 'button', $ai_button);
             }
 
 
             
 
         echo $Form->form_end();
+?>
+<script>
+document.getElementById('btnGenerateAI').addEventListener('click', function(e){
+    e.preventDefault();
+    var prompt = window.prompt('Enter prompt for AI content');
+    if(!prompt) return;
+    fetch('<?php echo PERCH_LOGINPATH; ?>/addons/apps/perch_blog/ai/generate.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({prompt: prompt})
+    }).then(function(r){return r.json();}).then(function(data){
+        var textarea = document.querySelector('#blog-edit textarea');
+        if(textarea) textarea.value = data.content;
+    });
+});
+</script>
+<?php
         /* ---- /FORM ---- */
 
     } // if edit_mode

--- a/perch/core/apps/content/PerchContent_AI.class.php
+++ b/perch/core/apps/content/PerchContent_AI.class.php
@@ -1,0 +1,45 @@
+<?php
+class PerchContent_AI
+{
+    private $api_key;
+
+    public function __construct()
+    {
+        $this->api_key = getenv('OPENAI_API_KEY');
+    }
+
+    public function generate($prompt)
+    {
+        if (!$this->api_key) {
+            return 'OpenAI API key is not set.';
+        }
+
+        $ch = curl_init('https://api.openai.com/v1/completions');
+        $data = [
+            'model' => 'text-davinci-003',
+            'prompt' => $prompt,
+            'max_tokens' => 150,
+        ];
+
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . $this->api_key,
+        ]);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+
+        $response = curl_exec($ch);
+        if ($response === false) {
+            return 'Failed to contact AI service.';
+        }
+
+        $resp = json_decode($response, true);
+        if (isset($resp['choices'][0]['text'])) {
+            return trim($resp['choices'][0]['text']);
+        }
+
+        return 'No content generated.';
+    }
+}
+?>

--- a/perch/core/apps/content/ai/generate.php
+++ b/perch/core/apps/content/ai/generate.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/../PerchContent_AI.class.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+$prompt = isset($input['prompt']) ? $input['prompt'] : '';
+
+$ai = new PerchContent_AI();
+$content = $ai->generate($prompt);
+
+echo json_encode(['content' => $content]);
+?>

--- a/perch/core/apps/content/modes/edit.form.post.php
+++ b/perch/core/apps/content/modes/edit.form.post.php
@@ -213,11 +213,13 @@ if (PERCH_RUNWAY) {
             </div>
             <div class="submit-bar-actions">
             <?php 
-                echo $Form->submit('btnsubmit', 'Save changes'); 
-                
+                echo $Form->submit('btnsubmit', 'Save changes');
+
                 if ($Region->regionMultiple()=='1') {
                     echo ' <input type="submit" name="add_another" value="'.PerchUtil::html(PerchLang::get('Save & add another')).'" id="add_another" class="button button-simple" />';
                 }
+
+                echo ' <button type="button" id="btnGenerateAI" class="button button-simple">'.PerchUtil::html(PerchLang::get('Generate with AI')).'</button>';
                 
                 
                 
@@ -252,3 +254,18 @@ if (PERCH_RUNWAY) {
         ?>
     
 </form>
+<script>
+document.getElementById('btnGenerateAI').addEventListener('click', function(e){
+    e.preventDefault();
+    var prompt = window.prompt('Enter prompt for AI content');
+    if(!prompt) return;
+    fetch('<?php echo PERCH_LOGINPATH; ?>/core/apps/content/ai/generate.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({prompt: prompt})
+    }).then(function(r){return r.json();}).then(function(data){
+        var textarea = document.querySelector('#content-edit textarea');
+        if(textarea) textarea.value = data.content;
+    });
+});
+</script>


### PR DESCRIPTION
## Summary
- add PerchContent_AI class that connects to OpenAI to generate text
- expose `/core/apps/content/ai/generate.php` endpoint for content creation requests
- update region editor with "Generate with AI" button and script to populate content fields
- add PerchBlog_AI class and blog `/ai/generate.php` endpoint
- include "Generate with AI" button and handler in blog post editor

## Testing
- `php -l perch/core/apps/content/PerchContent_AI.class.php`
- `php -l perch/core/apps/content/ai/generate.php`
- `php -l perch/core/apps/content/modes/edit.form.post.php`
- `php -l perch/addons/apps/perch_blog/lib/PerchBlog_AI.class.php`
- `php -l perch/addons/apps/perch_blog/ai/generate.php`
- `php -l perch/addons/apps/perch_blog/modes/edit.post.php`


------
https://chatgpt.com/codex/tasks/task_b_689b3334fa548324872a02c77c1d0bb2