### PR TITLE
Improve AI error handling

### DIFF
--- a/perch/addons/apps/perch_blog/lib/PerchBlog_AI.class.php
+++ b/perch/addons/apps/perch_blog/lib/PerchBlog_AI.class.php
@@ -30,15 +30,21 @@ class PerchBlog_AI
         curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
 
         $response = curl_exec($ch);
+        $http_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($response === false) {
+            PerchUtil::debug('OpenAI cURL error: ' . curl_error($ch));
             return 'Failed to contact AI service.';
         }
 
         $resp = json_decode($response, true);
+        if (isset($resp['error']['message'])) {
+            return $resp['error']['message'];
+        }
         if (isset($resp['choices'][0]['text'])) {
             return trim($resp['choices'][0]['text']);
         }
 
+        PerchUtil::debug('OpenAI HTTP status: ' . $http_status);
         return 'No content generated.';
     }
 }

--- a/perch/core/apps/content/PerchContent_AI.class.php
+++ b/perch/core/apps/content/PerchContent_AI.class.php
@@ -30,15 +30,21 @@ class PerchContent_AI
         curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
 
         $response = curl_exec($ch);
+        $http_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($response === false) {
+            PerchUtil::debug('OpenAI cURL error: ' . curl_error($ch));
             return 'Failed to contact AI service.';
         }
 
         $resp = json_decode($response, true);
+        if (isset($resp['error']['message'])) {
+            return $resp['error']['message'];
+        }
         if (isset($resp['choices'][0]['text'])) {
             return trim($resp['choices'][0]['text']);
         }
 
+        PerchUtil::debug('OpenAI HTTP status: ' . $http_status);
         return 'No content generated.';
     }
 }


### PR DESCRIPTION
## Summary
- return detailed OpenAI API error messages instead of generic responses
- log cURL errors and HTTP status codes for debugging

## Testing
- `php -l perch/core/apps/content/PerchContent_AI.class.php`
- `php -l perch/addons/apps/perch_blog/lib/PerchBlog_AI.class.php`


------
https://chatgpt.com/codex/tasks/task_b_689c5dd899448324aabd0ae5b475c9ea