### PR TITLE
Use gpt-3.5-turbo-instruct for AI content

### DIFF
--- a/perch/addons/apps/perch_blog/lib/PerchBlog_AI.class.php
+++ b/perch/addons/apps/perch_blog/lib/PerchBlog_AI.class.php
@@ -16,7 +16,7 @@ class PerchBlog_AI
 
         $ch = curl_init('https://api.openai.com/v1/completions');
         $data = [
-            'model' => 'text-davinci-003',
+            'model' => 'gpt-3.5-turbo-instruct',
             'prompt' => $prompt,
             'max_tokens' => 150,
         ];

--- a/perch/core/apps/content/PerchContent_AI.class.php
+++ b/perch/core/apps/content/PerchContent_AI.class.php
@@ -16,7 +16,7 @@ class PerchContent_AI
 
         $ch = curl_init('https://api.openai.com/v1/completions');
         $data = [
-            'model' => 'text-davinci-003',
+            'model' => 'gpt-3.5-turbo-instruct',
             'prompt' => $prompt,
             'max_tokens' => 150,
         ];


### PR DESCRIPTION
## Summary
- replace deprecated `text-davinci-003` model with `gpt-3.5-turbo-instruct` for content and blog AI helpers

## Testing
- `php -l perch/core/apps/content/PerchContent_AI.class.php`
- `php -l perch/addons/apps/perch_blog/lib/PerchBlog_AI.class.php`


------
https://chatgpt.com/codex/tasks/task_b_689c7952ef008324a6184e18262b5eaf