### PR TITLE
Normalize root product parent IDs

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
@@ -543,9 +543,13 @@ class PerchShop_Product extends PerchShop_Base
 
         $data = array();
 
-        if ($parentID) {
-            $data['parentID'] = $parentID;
-        }else{
+        if ($parentID !== false) {
+            if ($parentID === null) {
+                $data['parentID'] = null;
+            } else {
+                $data['parentID'] = $parentID;
+            }
+        } else {
             $data['parentID'] = $this->parentID();
         }
 

--- a/perch/addons/apps/perch_shop_products/modes/product.reorder.pre.php
+++ b/perch/addons/apps/perch_shop_products/modes/product.reorder.pre.php
@@ -13,9 +13,11 @@
 
                                 	             if (trim($str)!='') {
                                                                 	                    $parts = explode('=', $str);
-                                                                	                    $productID = str_replace(array('product[',']'), '', $parts[0]);
-                                                                	                    $parentID = $parts[1];
-                                                                	                      if ($parentID == 'root') $parentID = '0';
+                                                                                            $productID = str_replace(array('product[',']'), '', $parts[0]);
+                                                                                            $parentID = $parts[1];
+                                                                                              if (in_array($parentID, ['root', 'null', '0', ''], true)) {
+                                                                                                  $parentID = null;
+                                                                                              }
 
                                                                                                         	                    if (!isset($sort_orders[$parentID])) {
                                                                                                         	                        $sort_orders[$parentID] = 1;


### PR DESCRIPTION
## Summary
- normalize root and null-like parent IDs before updating product positions
- allow explicit null parent IDs when updating product tree positions

## Testing
- `php -l perch/addons/apps/perch_shop_products/modes/product.reorder.pre.php`
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php`
- `php -r 'function update_tree_position($parentID=false,$order=false){$data=[];if($parentID!==false){if($parentID===null){$data["parentID"]=null;}else{$data["parentID"]=$parentID;}}else{$data["parentID"]=5;}if($order){$data["productOrder"]=$order;}else{$data["productOrder"]=99;}return $data;}$data=update_tree_position(null,4);var_export($data);$pdo=new PDO("sqlite::memory:");$pdo->exec("CREATE TABLE products(id INTEGER PRIMARY KEY,parentID INTEGER NULL,productOrder INTEGER)");$stmt=$pdo->prepare("INSERT INTO products(id,parentID,productOrder) VALUES(1,:parentID,:productOrder)");$stmt->execute($data);$res=$pdo->query("SELECT id,parentID,productOrder FROM products WHERE parentID IS NULL")->fetchAll(PDO::FETCH_ASSOC);var_export($res);'`

------
https://chatgpt.com/codex/tasks/task_b_689c981496f48324a89203e3d49a1a81