### PR TITLE
Handle tax inclusive pricing for international customers

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
@@ -382,32 +382,32 @@ class PerchShop_Product extends PerchShop_Base
                 // Whos tax rate do we use?
                 $TaxGroup = $this->get_tax_group();
 
+                // Always get the home tax rate
+                $home_tax_rate = $TaxRates->get_rate_for_location((int)$TaxGroup->id(), (int)$HomeTaxLocation->id());
+
                 if ($TaxGroup->groupTaxRate()=='buyer') {
                     $TaxLocation = $CustomerTaxLocation;
                 }else{
                     $TaxLocation = $HomeTaxLocation;
                 }
 
-                // Which rate to charge? Standard, reduced etc
+                // Rate to charge based on buyer location decision
                 $tax_rate = $TaxRates->get_rate_for_location((int)$TaxGroup->id(), (int)$TaxLocation->id());
 
-                // Add or remove tax?
-                $multiplier = 1 + ($tax_rate/100);
-
+                // Calculate exclusive price
                 if ($prices_tax_inclusive) {
-                    // remove tax from base price
-                    $exclusive_price = $base_price / $multiplier;
-                    $inclusive_price = $base_price;
+                    $exclusive_price = $base_price / (1 + $home_tax_rate/100);
                 }else{
-                    // add tax to base price
                     $exclusive_price = $base_price;
-                    $inclusive_price = $base_price * $multiplier;
                 }
 
+                // Calculate inclusive price using buyer's tax rate
+                $inclusive_price = $exclusive_price * (1 + $tax_rate/100);
+
                 $Totaliser->add_to_items($exclusive_price*$qty, $tax_rate);
-                
+
                 if ($customer_pays_tax) {
-                    $Totaliser->add_to_tax(($inclusive_price - $exclusive_price)*$qty, $tax_rate);    
+                    $Totaliser->add_to_tax(($inclusive_price - $exclusive_price)*$qty, $tax_rate);
                 }
 
                 if (!$customer_pays_tax) {

--- a/perch/addons/apps/perch_shop/tests/TaxInclusivePriceTest.php
+++ b/perch/addons/apps/perch_shop/tests/TaxInclusivePriceTest.php
@@ -1,0 +1,143 @@
+<?php
+
+define('PERCH_RUNWAY', true);
+
+class PerchShop_Base
+{
+    protected $details;
+    public $api;
+
+    public function __construct($details = [])
+    {
+        $this->details = $details;
+        $this->api     = null;
+    }
+
+    public function get($val)
+    {
+        return $this->details[$val] ?? false;
+    }
+}
+
+class PerchShop_TaxGroup
+{
+    private $id;
+    private $rateType;
+
+    public function __construct($id, $rateType)
+    {
+        $this->id       = $id;
+        $this->rateType = $rateType;
+    }
+
+    public function id()
+    {
+        return $this->id;
+    }
+
+    public function groupTaxRate()
+    {
+        return $this->rateType;
+    }
+}
+
+class PerchShop_TaxRates
+{
+    public function __construct($api)
+    {
+    }
+
+    public function get_rate_for_location($groupID, $locationID)
+    {
+        if ($locationID == 100) {
+            return 20; // UK home rate
+        }
+
+        return 0; // Non-UK
+    }
+}
+
+class PerchShop_TaxLocation
+{
+    private $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function id()
+    {
+        return $this->id;
+    }
+}
+
+class PerchShop_Currency
+{
+    private $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function id()
+    {
+        return $this->id;
+    }
+
+    public function format_numeric($number)
+    {
+        return number_format($number, 2, '.', '');
+    }
+
+    public function format_display($number)
+    {
+        return '£' . number_format($number, 2, '.', '');
+    }
+}
+
+require_once __DIR__ . '/../lib/PerchShop_CartTotaliser.class.php';
+require_once __DIR__ . '/../lib/PerchShop_Product.class.php';
+
+class TestProduct extends PerchShop_Product
+{
+    public function __construct($details)
+    {
+        $this->details = $details;
+        $this->api     = null;
+    }
+
+    public function get_tax_group()
+    {
+        return new PerchShop_TaxGroup(1, 'buyer');
+    }
+
+    public function get_property($prop, PerchShop_Product $Parent=null)
+    {
+        return $this->details[$prop] ?? false;
+    }
+}
+
+$Product             = new TestProduct(['price' => [1 => 120]]);
+$CustomerTaxLocation = new PerchShop_TaxLocation(200); // non-UK buyer
+$HomeTaxLocation     = new PerchShop_TaxLocation(100); // UK home
+$Currency            = new PerchShop_Currency(1);
+$Totaliser           = new PerchShop_CartTotaliser();
+
+$price = $Product->get_prices(1, 'standard', 'inc', $CustomerTaxLocation, $HomeTaxLocation, $Currency, $Totaliser);
+
+if ($price['price_with_tax'] !== '100.00') {
+    throw new Exception('Inclusive price incorrect');
+}
+
+if ($price['tax'] !== '0.00') {
+    throw new Exception('Tax amount incorrect');
+}
+
+if ($price['tax_formatted'] !== '£0.00') {
+    throw new Exception('Formatted tax incorrect');
+}
+
+echo "Test passed\n";
+


### PR DESCRIPTION
## Summary
- Use home tax rate when stripping tax from base prices and recompute inclusive price with buyer's rate
- Verify tax-inclusive UK price decreases to exclude VAT for non-UK buyer and VAT lines show £0.00

## Testing
- `php perch/addons/apps/perch_shop/tests/TaxInclusivePriceTest.php`

------
https://chatgpt.com/codex/tasks/task_b_689ca89bdd888324b753f36ddd385c0d