### PR TITLE
Handle empty shipping categories in cart option filtering

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Shippings.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Shippings.class.php
@@ -37,15 +37,13 @@ class PerchShop_Shippings extends PerchShop_Factory
 				}
 			}
 
-			if (is_array($cart_product_categories) && count($cart_product_categories) > 0) {
+                        if (is_array($cart_product_categories) && count($cart_product_categories) > 0) {
 
-			$commonValues = array_intersect($cart_product_categories, $shipping["category"]);
-
-
-            if (empty($commonValues)) {
-                return false;
-            }
-			}
+                                if (isset($shipping['category']) && is_array($shipping['category']) && count($shipping['category'])) {
+                                        $commonValues = array_intersect($cart_product_categories, $shipping['category']);
+                                        if (empty($commonValues)) return false;
+                                }
+                        }
 
 
 			// Cart weight is less than min shipping weight


### PR DESCRIPTION
## Summary
- guard against empty shipping categories before intersecting with cart product categories

## Testing
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_Shippings.class.php`
- ⚠️ `phpunit --version` (command not found)
- ⚠️ `apt-get update` (failed: repository is not signed)


------
https://chatgpt.com/codex/tasks/task_b_689dbb2eb3bc8324b5c8a709079f9259