### PR TITLE
Add member impersonation feature

### DIFF
--- a/perch/addons/apps/perch_members/impersonate/index.php
+++ b/perch/addons/apps/perch_members/impersonate/index.php
@@ -1,0 +1,28 @@
+<?php
+    # include the API
+    include('../../../../core/inc/api.php');
+
+    $API  = new PerchAPI(1.0, 'perch_members');
+    $Lang = $API->get('Lang');
+
+    # include your class files
+    include('../PerchMembers_Members.class.php');
+    include('../PerchMembers_Member.class.php');
+    include('../PerchMembers_Auth.class.php');
+
+    # Set the page title
+    $Perch->page_title = $Lang->get('Impersonate member');
+
+    # Do anything you want to do before output is started
+    include('../modes/members.impersonate.pre.php');
+
+    # Top layout
+    include(PERCH_CORE . '/inc/top.php');
+
+    # Display your page
+    include('../modes/members.impersonate.post.php');
+
+    # Bottom layout
+    include(PERCH_CORE . '/inc/btm.php');
+?>
+

--- a/perch/addons/apps/perch_members/modes/members.impersonate.post.php
+++ b/perch/addons/apps/perch_members/modes/members.impersonate.post.php
@@ -1,0 +1,6 @@
+<?php
+
+    if ($message) {
+        echo $message;
+    }
+

--- a/perch/addons/apps/perch_members/modes/members.impersonate.pre.php
+++ b/perch/addons/apps/perch_members/modes/members.impersonate.pre.php
@@ -1,0 +1,36 @@
+<?php
+
+    $Members = new PerchMembers_Members($API);
+    $Auth    = new PerchMembers_Auth($API);
+    $HTML    = $API->get('HTML');
+
+    $message = false;
+
+    if (PerchRequest::get('end')) {
+        $Auth->log_out();
+        $message = $HTML->success_message('Impersonation ended. <a href="'.$API->app_path().'/">Return to admin</a>');
+    } else {
+
+        if (!$CurrentUser->has_priv('perch_members.impersonate')) {
+            PerchUtil::redirect($API->app_path());
+        }
+
+        $memberID = PerchRequest::get('id');
+
+        if ($memberID) {
+            $Member = $Members->find($memberID);
+        }
+
+        if (!is_object($Member)) {
+            PerchUtil::redirect($API->app_path());
+        }
+
+        $Auth->refresh_session_data($Member);
+
+        $log_line = sprintf('[%s] Admin %d impersonated member %d'."\n", date('Y-m-d H:i:s'), $CurrentUser->id(), $Member->id());
+        $log_file = PERCH_PATH.'/addons/apps/perch_members/impersonate.log';
+        file_put_contents($log_file, $log_line, FILE_APPEND);
+
+        PerchUtil::redirect('/shop/index.php');
+    }
+

--- a/perch/addons/apps/perch_members/modes/members.list.post.php
+++ b/perch/addons/apps/perch_members/modes/members.list.post.php
@@ -160,6 +160,14 @@
                     'inline' => true,
                     'path'   => 'delete',
                 ]);
+
+        $Listing->add_misc_action([
+                    'title' => $Lang->get('Login as'),
+                    'path'  => function($item) {
+                        return 'impersonate/?id=' . $item->id();
+                    },
+                    'priv'  => 'perch_members.impersonate',
+                ]);
         
             
         echo $Listing->render($members);


### PR DESCRIPTION
## Summary
- allow admins to impersonate members via new "Login as" action
- add controller and modes to create member sessions and log actions
- provide endpoint to end impersonation and return to admin

## Testing
- `php -l perch/addons/apps/perch_members/modes/members.list.post.php`
- `php -l perch/addons/apps/perch_members/impersonate/index.php`
- `php -l perch/addons/apps/perch_members/modes/members.impersonate.pre.php`
- `php -l perch/addons/apps/perch_members/modes/members.impersonate.post.php`


------
https://chatgpt.com/codex/tasks/task_b_689ddd0efb808324967c76f95ba8e710