### PR TITLE
Add Akismet API key setting for member sign-ups

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Members.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Members.class.php
@@ -172,7 +172,7 @@ class PerchMembers_Members extends PerchAPI_Factory
 	    	$member['memberProperties'] = PerchUtil::json_safe_encode($properties);
 	    	// Anti-spam
             $Settings = $this->api->get('Settings');
-            $akismetAPIKey =$Settings->get('perch_blog_akismet_key')->val();
+            $akismetAPIKey = $Settings->get('perch_members_akismet_key')->val();
 
              $spam = false;
             $antispam = $SubmittedForm->get_antispam_values();

--- a/perch/addons/apps/perch_members/admin.php
+++ b/perch/addons/apps/perch_members/admin.php
@@ -2,8 +2,9 @@
 	if ($CurrentUser->logged_in() && $CurrentUser->has_priv('perch_members')) {
 	    $this->register_app('perch_members', 'Members', 2, 'Manage site members', '1.6.6');
 	    $this->require_version('perch_members', '3.1.1');
-	    $this->add_setting('perch_members_login_page', 'Login page path', 'text', '/members/login.php?r={returnURL}');
-	}
+            $this->add_setting('perch_members_login_page', 'Login page path', 'text', '/members/login.php?r={returnURL}');
+            $this->add_setting('perch_members_akismet_key', 'Akismet API key', 'text', '');
+        }
 
 	spl_autoload_register(function($class_name){
     	if (strpos($class_name, 'PerchMembers')===0) {

--- a/perch/addons/apps/perch_members/help.php
+++ b/perch/addons/apps/perch_members/help.php
@@ -1,0 +1,1 @@
+<p>The Members app enables you to manage user accounts. Enter your Akismet API key in the Members settings to check new sign-ups for spam.</p>

--- a/perch/addons/apps/perch_members/lang/en-gb.txt
+++ b/perch/addons/apps/perch_members/lang/en-gb.txt
@@ -50,6 +50,7 @@
     "Send welcome email": "Send welcome email",
     "Will only be sent to active members": "Will only be sent to active members",
     "Login page path": "Login page path",
+    "Akismet API key": "Akismet API key",
     "Manage members": "Manage members",
     "Forms": "Forms",
     "Active": "Active",


### PR DESCRIPTION
## Summary
- add `perch_members_akismet_key` setting for spam protection
- use Members app's Akismet key during registration
- document new Akismet setting

## Testing
- `php -l perch/addons/apps/perch_members/admin.php`
- `php -l perch/addons/apps/perch_members/PerchMembers_Members.class.php`
- `php -l perch/addons/apps/perch_members/help.php`


------
https://chatgpt.com/codex/tasks/task_b_68a34cb07164832493e072bd9da1893b