### PR TITLE
Cast shipping categories before intersect to avoid warnings

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Shippings.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Shippings.class.php
@@ -39,8 +39,9 @@ class PerchShop_Shippings extends PerchShop_Factory
 
                         if (is_array($cart_product_categories) && count($cart_product_categories) > 0) {
 
-                                if (isset($shipping['category']) && is_array($shipping['category']) && count($shipping['category'])) {
-                                        $commonValues = array_intersect($cart_product_categories, $shipping['category']);
+                                $shippingCategories = isset($shipping['category']) ? (array)$shipping['category'] : [];
+                                if ($shippingCategories && is_array($cart_product_categories)) {
+                                        $commonValues = array_intersect($cart_product_categories, $shippingCategories);
                                         if (empty($commonValues)) return false;
                                 }
                         }


### PR DESCRIPTION
## Summary
- cast shipping categories to array before intersecting with cart categories to avoid warnings when shipping category is not an array

## Testing
- `php perch/addons/apps/perch_shop/tests/TaxInclusivePriceTest.php`

------
https://chatgpt.com/codex/tasks/task_b_68a6e74500108324b4ba7502c94e54c1