### PR TITLE
Add package management classes and runtime helpers

### DIFF
--- a/perch/addons/apps/perch_shop/db.sql
+++ b/perch/addons/apps/perch_shop/db.sql
@@ -474,3 +474,22 @@ CREATE TABLE IF NOT EXISTS `__PREFIX__shop_sales` (
   `saleDeleted` datetime DEFAULT NULL,
   PRIMARY KEY (`saleID`)
 ) CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `__PREFIX__shop_packages` (
+  `packageID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `customerID` int(10) unsigned NOT NULL DEFAULT '0',
+  `month` char(7) NOT NULL DEFAULT '',
+  `status` char(32) NOT NULL DEFAULT '',
+  PRIMARY KEY (`packageID`),
+  KEY `idx_customer` (`customerID`)
+) CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `__PREFIX__shop_package_items` (
+  `itemID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `packageID` int(10) unsigned NOT NULL DEFAULT '0',
+  `productID` int(10) unsigned NOT NULL DEFAULT '0',
+  `variantID` int(10) unsigned DEFAULT NULL,
+  `qty` int(10) unsigned NOT NULL DEFAULT '1',
+  PRIMARY KEY (`itemID`),
+  KEY `idx_package` (`packageID`)
+) CHARSET=utf8;

--- a/perch/addons/apps/perch_shop/lib/PerchShop_Package.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Package.class.php
@@ -1,0 +1,18 @@
+<?php
+
+class PerchShop_Package extends PerchShop_Base
+{
+    protected $factory_classname = 'PerchShop_Packages';
+    protected $table             = 'shop_packages';
+    protected $pk                = 'packageID';
+    protected $index_table       = false;
+
+    protected $event_prefix = 'shop.package';
+
+    public function get_items()
+    {
+        $Items = new PerchShop_PackageItems($this->api);
+        return $Items->get_for_package($this->id());
+    }
+}
+

--- a/perch/addons/apps/perch_shop/lib/PerchShop_PackageItem.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_PackageItem.class.php
@@ -1,0 +1,12 @@
+<?php
+
+class PerchShop_PackageItem extends PerchShop_Base
+{
+    protected $factory_classname = 'PerchShop_PackageItems';
+    protected $table             = 'shop_package_items';
+    protected $pk                = 'itemID';
+    protected $index_table       = false;
+
+    protected $event_prefix = 'shop.packageitem';
+}
+

--- a/perch/addons/apps/perch_shop/lib/PerchShop_PackageItems.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_PackageItems.class.php
@@ -1,0 +1,23 @@
+<?php
+
+class PerchShop_PackageItems extends PerchShop_Factory
+{
+    public $api_method         = 'packages';
+    public $api_list_method    = 'packages';
+    public $singular_classname = 'PerchShop_PackageItem';
+    public $static_fields      = ['packageID', 'productID', 'variantID', 'qty'];
+
+    protected $table               = 'shop_package_items';
+    protected $pk                  = 'itemID';
+    protected $index_table         = false;
+    protected $default_sort_column = 'itemID';
+
+    protected $event_prefix = 'shop.packageitem';
+
+    public function get_for_package($packageID)
+    {
+        $sql = 'SELECT * FROM ' . $this->table . ' WHERE packageID=' . $this->db->pdb((int)$packageID);
+        return $this->return_instances($this->db->get_rows($sql));
+    }
+}
+

--- a/perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php
@@ -1,0 +1,23 @@
+<?php
+
+class PerchShop_Packages extends PerchShop_Factory
+{
+    public $api_method         = 'packages';
+    public $api_list_method    = 'packages';
+    public $singular_classname = 'PerchShop_Package';
+    public $static_fields      = ['customerID', 'month', 'status'];
+    public $remote_fields      = ['customerID', 'month', 'status'];
+
+    protected $table               = 'shop_packages';
+    protected $pk                  = 'packageID';
+    protected $default_sort_column = 'packageID';
+
+    protected $event_prefix = 'shop.package';
+
+    public function get_for_customer($customerID)
+    {
+        $sql = 'SELECT * FROM ' . $this->table . ' WHERE customerID=' . $this->db->pdb((int)$customerID);
+        return $this->return_instances($this->db->get_rows($sql));
+    }
+}
+

--- a/perch/addons/apps/perch_shop/runtime.php
+++ b/perch/addons/apps/perch_shop/runtime.php
@@ -37,8 +37,9 @@
 	include(__DIR__.'/runtime/cart.php');
 	include(__DIR__.'/runtime/orders.php');
 	include(__DIR__.'/runtime/email.php');
-	include(__DIR__.'/runtime/gateways.php');
-	include(__DIR__.'/runtime/customers.php');
-	include(__DIR__.'/runtime/events.php');
-	include(__DIR__.'/events.php');
+        include(__DIR__.'/runtime/gateways.php');
+        include(__DIR__.'/runtime/customers.php');
+        include(__DIR__.'/runtime/events.php');
+        include(__DIR__.'/runtime/packages.php');
+        include(__DIR__.'/events.php');
 

--- a/perch/addons/apps/perch_shop/runtime/packages.php
+++ b/perch/addons/apps/perch_shop/runtime/packages.php
@@ -1,0 +1,17 @@
+<?php
+
+function perch_shop_create_package($data)
+{
+    $API      = new PerchAPI(1.0, 'perch_shop');
+    $Packages = new PerchShop_Packages($API);
+    return $Packages->create($data);
+}
+
+function perch_shop_add_package_item($packageID, $data)
+{
+    $API   = new PerchAPI(1.0, 'perch_shop');
+    $Items = new PerchShop_PackageItems($API);
+    $data['packageID'] = $packageID;
+    return $Items->create($data);
+}
+


### PR DESCRIPTION
## Summary
- add `shop_packages` and `shop_package_items` tables
- implement `PerchShop_Package` and related factory classes
- expose `perch_shop_create_package` and `perch_shop_add_package_item` runtime helpers

## Testing
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_Package.class.php`
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php`
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_PackageItem.class.php`
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_PackageItems.class.php`
- `php -l perch/addons/apps/perch_shop/runtime/packages.php`
- `./lib/vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a6e98ff54c8324946142d3942039b5