### PR TITLE
Automate monthly package processing

### DIFF
--- a/perch/addons/apps/perch_shop/scheduled_tasks.php
+++ b/perch/addons/apps/perch_shop/scheduled_tasks.php
@@ -1,0 +1,7 @@
+<?php
+
+// Register the package processing task to run daily
+include __DIR__.'/scripts/process_packages.php';
+
+PerchScheduledTasks::register_task('perch_shop', 'process_packages', 1440, 'perch_shop_process_packages');
+

--- a/perch/addons/apps/perch_shop/scripts/process_packages.php
+++ b/perch/addons/apps/perch_shop/scripts/process_packages.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Process monthly packages and convert them into orders.
+ *
+ * Loads all packages scheduled for the current month, adds their items to a
+ * cart using the PerchShop runtime and attempts checkout. The package record is
+ * updated to reflect success or failure and confirmation emails are optionally
+ * sent using existing order email templates.
+ *
+ * @param string $last_run Timestamp of last execution provided by scheduler.
+ *
+ * @return array Result information for the scheduler log.
+ */
+function perch_shop_process_packages($last_run = null)
+{
+    $API = new PerchAPI(1.0, 'perch_shop');
+    $DB  = $API->get('DB');
+
+    // Ensure we have a session for cart operations
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+
+    $Runtime = PerchShop_Runtime::fetch();
+
+    $start = date('Y-m-01');
+    $end   = date('Y-m-t');
+
+    $sql = 'SELECT * FROM '.PERCH_DB_PREFIX.'shop_packages '
+         . 'WHERE packageStatus='.$DB->pdb('pending')
+         . ' AND packageDate BETWEEN '.$DB->pdb($start)
+         . ' AND '.$DB->pdb($end);
+
+    $packages = $DB->get_rows($sql);
+    $processed = 0;
+
+    if (PerchUtil::count($packages)) {
+        foreach ($packages as $package) {
+            // reset cart for this package
+            $Runtime->reset_after_logout();
+
+            $item_sql = 'SELECT productID, itemQty FROM '
+                     . PERCH_DB_PREFIX.'shop_package_items '
+                     . 'WHERE packageID='.$DB->pdb($package['packageID']);
+            $items = $DB->get_rows($item_sql);
+
+            if (PerchUtil::count($items)) {
+                foreach ($items as $item) {
+                    $Runtime->add_to_cart($item['productID'], (int)$item['itemQty']);
+                }
+
+                // Attempt checkout using the manual gateway
+                $Runtime->checkout('manual');
+                $Order = $Runtime->Order;
+
+                if ($Order && $Order->id()) {
+                    // Update package as processed and store order ID
+                    $DB->update(
+                        PERCH_DB_PREFIX.'shop_packages',
+                        ['packageStatus' => 'processed', 'orderID' => $Order->id()],
+                        'packageID',
+                        $package['packageID']
+                    );
+
+                    // Send confirmation emails for this order status
+                    $Emails = new PerchShop_Emails($API);
+                    $emails = $Emails->get_for_status($Order->orderStatus());
+                    if (PerchUtil::count($emails)) {
+                        foreach ($emails as $Email) {
+                            $Order->send_order_email($Email);
+                        }
+                    }
+
+                    $processed++;
+                } else {
+                    // Failed checkout
+                    $DB->update(
+                        PERCH_DB_PREFIX.'shop_packages',
+                        ['packageStatus' => 'failed'],
+                        'packageID',
+                        $package['packageID']
+                    );
+                }
+            } else {
+                // No items found for package
+                $DB->update(
+                    PERCH_DB_PREFIX.'shop_packages',
+                    ['packageStatus' => 'failed'],
+                    'packageID',
+                    $package['packageID']
+                );
+            }
+
+            // Clear cart/session for next package
+            $Runtime->reset_after_logout();
+        }
+    }
+
+    if (session_status() === PHP_SESSION_ACTIVE) {
+        session_write_close();
+    }
+
+    $message = $processed
+        ? $processed.' packages processed.'
+        : 'No packages to process.';
+
+    return [
+        'result'  => 'OK',
+        'message' => $message,
+    ];
+}
+


### PR DESCRIPTION
## Summary
- add cron-ready package processing script that converts monthly packages into orders, updates package status and emails confirmations
- register package processing task with the scheduled task system

## Testing
- `php -l perch/addons/apps/perch_shop/scripts/process_packages.php`
- `php -l perch/addons/apps/perch_shop/scheduled_tasks.php`


------
https://chatgpt.com/codex/tasks/task_b_68a6e992518c8324826f33570c16580d