### PR TITLE
Use variants loop for package builder options

### DIFF
--- a/perch/templates/shop/package-builder/product.html
+++ b/perch/templates/shop/package-builder/product.html
@@ -2,8 +2,12 @@
 <div class="package-product">
     <h2><perch:shop id="title" /></h2>
     <input type="hidden" name="product_id[]" value="<perch:shop id='productID' />" />
-    <perch:if exists="_variant_opts">
-        <perch:input type="select" id="variant[]" options="<perch:shop id='_variant_opts' type='hidden' />" />
+    <perch:if exists="variants">
+        <select id="variant[]" name="variant[]">
+            <perch:variants>
+                <option value="<perch:variants id='productID' />"><perch:variants id='title' /></option>
+            </perch:variants>
+        </select>
     <perch:else />
         <input type="hidden" name="variant[]" value="<perch:shop id='productID' />" />
     </perch:if>


### PR DESCRIPTION
## Summary
- Render package builder product variants with a `<perch:if exists="variants">` block and a `<perch:variants>` loop
- Keep hidden variant input as fallback for products without variants

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a75a9cbefc832481258f74fadf0661