### PR TITLE
Fix variant option loop in package builder template

### DIFF
--- a/perch/templates/shop/package-builder/product.html
+++ b/perch/templates/shop/package-builder/product.html
@@ -5,7 +5,7 @@
     <perch:if exists="variants">
         <select id="variant[]" name="variant[]">
             <perch:variants>
-                <option value="<perch:variants id='productID' />"><perch:variants id='title' /></option>
+                <option value="<perch:variant id='productID' />"><perch:variant id='title' /></option>
             </perch:variants>
         </select>
     <perch:else />

--- a/perch/templates/shop/package-builder/variant-options.html
+++ b/perch/templates/shop/package-builder/variant-options.html
@@ -1,0 +1,7 @@
+<perch:if exists="variants">
+    <perch:variants>
+        <option value="<perch:variant id='productID' />"><perch:shop id='title' /> - <perch:variant id='title' /></option>
+    </perch:variants>
+<perch:else />
+    <option value="<perch:shop id='productID' />"><perch:shop id='title' /></option>
+</perch:if>

--- a/shop/package-builder.php
+++ b/shop/package-builder.php
@@ -1,13 +1,13 @@
 <?php include('../perch/runtime.php');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $months   = (int) perch_post('months');
     $variants = perch_post('variant');
-    $quantities = perch_post('qty');
-    if (is_array($variants) && is_array($quantities)) {
-        foreach ($variants as $idx => $variantID) {
-            $qty = isset($quantities[$idx]) ? (int)$quantities[$idx] : 0;
-            if ($qty > 0 && $variantID) {
-                perch_shop_package_add_item($variantID, $qty);
+    if ($months && is_array($variants)) {
+        for ($i = 0; $i < $months; $i++) {
+            $variantID = $variants[$i] ?? null;
+            if ($variantID) {
+                perch_shop_package_add_item($variantID, 1);
             }
         }
     }
@@ -15,9 +15,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 ?>
 <form method="post">
-    <?php perch_shop_products([
-        'template' => 'package-builder/product.html',
-        'variants' => true,
-    ]); ?>
+    <label for="months">Months</label>
+    <select id="months" name="months">
+        <option value="4">4</option>
+        <option value="6">6</option>
+        <option value="12">12</option>
+    </select>
+
+    <?php for ($i = 1; $i <= 12; $i++): ?>
+    <div class="package-month">
+        <label>Month <?php echo $i; ?></label>
+        <select name="variant[]">
+            <?php perch_shop_products([
+                'template' => 'package-builder/variant-options.html',
+                'variants'  => true,
+            ]); ?>
+        </select>
+    </div>
+    <?php endfor; ?>
+
     <button type="submit">Save package</button>
 </form>


### PR DESCRIPTION
## Summary
- Replace `_variant_opts` usage with direct `<perch:variants>` loop using `<perch:variant>` tags for option values and titles
- Keep hidden `variant[]` input fallback when no variants exist
- Add month selection and per-month variant assignment in package builder
- Provide template for generating variant option tags

## Testing
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a83526969483248e6c33c3a12afdb0