### PR TITLE
Add customer selection to order editing

### DIFF
--- a/perch/addons/apps/perch_shop/templates/shop/orders/admin_order.html
+++ b/perch/addons/apps/perch_shop/templates/shop/orders/admin_order.html
@@ -1,4 +1,3 @@
-<perch:shop id="customer" type="text" label="Customer ID" required="true" />
 <perch:shop id="status" type="select" label="Status" options="created|created,paid|paid,processing|processing,dispatched|dispatched,cancelled|cancelled" required="true" />
 <perch:shop id="total" type="text" label="Order total" required="true" />
 <perch:shop id="gateway" type="text" label="Gateway" required="true" default="manual" />

--- a/perch/addons/apps/perch_shop_orders/modes/order.edit.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/order.edit.post.php
@@ -26,6 +26,8 @@
     echo $Form->form_start('edit');
 
         echo $Form->fields_from_template($Template, $details);
+        echo $Form->select_field('customer', 'Customer', $customer_opts, $details['customerID'] ?? '');
+        echo '<a class="action" href="'.$API->app_path('perch_shop_orders').'/customers/edit/">Add new customer</a>';
         echo $Form->submit_field('btnSubmit', 'Save', $API->app_path());
 
     echo $Form->form_end();

--- a/perch/addons/apps/perch_shop_orders/modes/order.edit.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/order.edit.pre.php
@@ -1,6 +1,18 @@
 <?php
     $Orders     = new PerchShop_Orders($API);
     $Currencies = new PerchShop_Currencies($API);
+    $Customers  = new PerchShop_Customers($API);
+
+    $customer_opts = [];
+    $customer_list = $Customers->all();
+    if (PerchUtil::count($customer_list)) {
+        foreach($customer_list as $Customer) {
+            $customer_opts[] = [
+                'value' => $Customer->id(),
+                'label' => $Customer->customerFirstName().' '.$Customer->customerLastName().' ('.$Customer->customerEmail().')',
+            ];
+        }
+    }
 
     $edit_mode = false;
     $Order     = false;
@@ -33,6 +45,12 @@
 
     if ($Form->submitted()) {
         $data = $Form->get_posted_content($Template, $Orders, $Order);
+
+        $postvars = ['customer'];
+        $more = $Form->receive($postvars);
+        if (isset($more['customer']) && $more['customer'] !== '') {
+            $data['customerID'] = $more['customer'];
+        }
 
         if (!$Order) {
             $Currency = $Currencies->get_default();


### PR DESCRIPTION
## Summary
- build customer option list for orders and map posted value to customerID
- add customer select field and link to new customer form in order editor
- remove obsolete customer ID field from admin order template

## Testing
- `php -l perch/addons/apps/perch_shop_orders/modes/order.edit.pre.php`
- `php -l perch/addons/apps/perch_shop_orders/modes/order.edit.post.php`


------
https://chatgpt.com/codex/tasks/task_b_68ab0c4dbad88324b0ccc917598bec44