### PR TITLE
Allow external assignment of invoice numbers

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
@@ -255,7 +255,7 @@ class PerchShop_Order extends PerchShop_Base
 		return $Gateway->produce_payment_response($args, $gateway_opts);
 	}
 
-    private function assign_invoice_number()
+    public function assign_invoice_number()
     {
         $number = $this->get_next_invoice_number();
         $Settings = $this->api->get('Settings');


### PR DESCRIPTION
## Summary
- Expose `assign_invoice_number()` on `PerchShop_Order` so other code can generate invoice numbers

## Testing
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php`
- `php -l perch/addons/apps/perch_shop_orders/modes/order.edit.pre.php`


------
https://chatgpt.com/codex/tasks/task_b_68ab0c5389f48324a78b4168945e25f7