### PR TITLE
Add customer selection to order editing

### DIFF
--- a/perch/addons/apps/perch_shop_orders/modes/order.edit.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/order.edit.post.php
@@ -26,6 +26,18 @@
     echo $Form->form_start('edit');
 
         echo $Form->fields_from_template($Template, $details);
+        echo $Form->select_field('customer', 'Customer', $customer_opts, $details['customerID'] ?? '');
+        echo '<script>
+                var sel = document.querySelector("select[name=customer]");
+                var txt = document.querySelector("input[name=customer]");
+                if (sel && txt) {
+                    txt.value = sel.value;
+                    sel.addEventListener("change", function() {
+                        txt.value = this.value;
+                    });
+                }
+              </script>';
+        echo '<a class="action" href="'.$API->app_path('perch_shop_orders').'/customers/edit/">Add new customer</a>';
         echo $Form->submit_field('btnSubmit', 'Save', $API->app_path());
 
     echo $Form->form_end();

--- a/perch/addons/apps/perch_shop_orders/modes/order.edit.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/order.edit.pre.php
@@ -1,6 +1,18 @@
 <?php
     $Orders     = new PerchShop_Orders($API);
     $Currencies = new PerchShop_Currencies($API);
+    $Customers  = new PerchShop_Customers($API);
+
+    $customer_opts = [];
+    $customer_list = $Customers->all();
+    if (PerchUtil::count($customer_list)) {
+        foreach($customer_list as $Customer) {
+            $customer_opts[] = [
+                'value' => $Customer->id(),
+                'label' => $Customer->customerFirstName().' '.$Customer->customerLastName().' ('.$Customer->customerEmail().')',
+            ];
+        }
+    }
 
     $edit_mode = false;
     $Order     = false;
@@ -34,6 +46,11 @@
     if ($Form->submitted()) {
         $data = $Form->get_posted_content($Template, $Orders, $Order);
 
+        if (isset($data['customer']) && $data['customer'] !== '') {
+            $data['customerID'] = (int)$data['customer'];
+            unset($data['customer']);
+        }
+
         if (!$Order) {
             $Currency = $Currencies->get_default();
             if ($Currency) {
@@ -41,6 +58,10 @@
             }
             $Order = $Orders->create($data);
             if ($Order) {
+                // ensure customer is persisted on creation
+                if (isset($data['customerID'])) {
+                    $Order->update(['customerID' => $data['customerID']]);
+                }
                 $Order->assign_invoice_number();
                 $Order->index($Template);
                 PerchUtil::redirect($Perch->get_page().'?id='.$Order->id().'&created=1');


### PR DESCRIPTION
## Summary
- build customer option list for orders and map posted value to customerID
- add customer select field and link to new customer form in order editor
- remove obsolete customer ID field from admin order template
- ensure selected customer persists to orders table when creating new orders
- mirror dropdown selection into customer ID field

## Testing
- `php -l perch/addons/apps/perch_shop_orders/modes/order.edit.pre.php`
- `php -l perch/addons/apps/perch_shop_orders/modes/order.edit.post.php`


------
https://chatgpt.com/codex/tasks/task_b_68ab0c4dbad88324b0ccc917598bec44