### PR TITLE
Fix admin member list sorting and filtering

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Members.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Members.class.php
@@ -35,9 +35,9 @@ class PerchMembers_Members extends PerchAPI_Factory
 	         foreach($filterdata as $key => $value){
               $value=json_decode($value, true);
               //print_r($value);print_r($value["status"]);
-              if($value["status"]!=null && !$results) {
-                  // echo "1";
-                $callstatus=$this->get_by('memberStatus', $value["status"], $Paging);
+                if($value["status"]!=null && !$results) {
+                    // echo "1";
+                  $callstatus=$this->get_by('memberStatus', $value["status"], false, $Paging);
                 if($callstatus!=null){
                    $results=true;
                   return $callstatus;
@@ -46,9 +46,9 @@ class PerchMembers_Members extends PerchAPI_Factory
 
               }
 
-                 if($value["email"]!=null && !$results) {
-                      //  echo "2";
-                        $callstatus=$this->get_by('memberEmail', $value["email"], $Paging);
+                if($value["email"]!=null && !$results) {
+                        //  echo "2";
+                          $callstatus=$this->get_by('memberEmail', $value["email"], false, $Paging);
                          if($callstatus!=null){
                              $results=true;
                              return $callstatus;
@@ -75,7 +75,7 @@ class PerchMembers_Members extends PerchAPI_Factory
                         }
 
     			     // print_r( $namearr);
-    			     $callstatus=$this->get_by('memberProperties', $namearr, $Paging);
+                               $callstatus=$this->get_by('memberProperties', $namearr, false, $Paging);
                       if($callstatus!=null){
                               $results=true;
                             return $callstatus;
@@ -91,7 +91,7 @@ class PerchMembers_Members extends PerchAPI_Factory
 			        	'op'=>"between"
 			            );
 			           // print_r( $daterange);
-                         return $this->get_by('memberCreated', $daterange , $Paging);
+                           return $this->get_by('memberCreated', $daterange , false, $Paging);
                     }
 
 
@@ -105,9 +105,9 @@ class PerchMembers_Members extends PerchAPI_Factory
 		return $this->get_by('memberStatus', $status, $sort,$Paging);
 	}
 
-	public function get_by_email($email='nan', $Paging=false)
+        public function get_by_email($email='nan', $Paging=false)
     {
-        return $this->get_by('memberEmail', $email, $Paging);
+        return $this->get_by('memberEmail', $email, false, $Paging);
     }
 
 	private function _check_for_spam($fields, $environment, $akismetAPIKey=false)

--- a/perch/addons/apps/perch_members/modes/members.list.pre.php
+++ b/perch/addons/apps/perch_members/modes/members.list.pre.php
@@ -99,11 +99,6 @@ if($filter!="memberProperties"){
     }
     }
 
- $sort=false;
-if (isset($_GET['sort']) && $_GET['sort'] != '') {
-        $sort = $_GET['sort'];
-
-        }
     switch ($filter) {
 
         case 'tag':
@@ -111,23 +106,23 @@ if (isset($_GET['sort']) && $_GET['sort'] != '') {
             break;
 
         case 'email':
-            $members = $Members->get_by_email($email);
+            $members = $Members->get_by_email($email, $Paging);
             break;
 
         case 'status':
             if ($status == 'all') {
                 $members = $Members->all($Paging);
             }else{
-                $members = $Members->get_by_status($status,$sort, $Paging);
+                $members = $Members->get_by_status($status, false, $Paging);
             }
              break;
         case 'memberProperties':
-          $members = $Members->get_by_properties($filerdata);
+          $members = $Members->get_by_properties($filerdata, $Paging);
           break;
 
 
         default:
-            $members = $Members->get_by_status('pending');
+            $members = $Members->get_by_status('pending', false, $Paging);
 
 
             break;


### PR DESCRIPTION
## Summary
- delegate admin member list sorting to built-in paging
- pass paging object to member filters for proper sorting and pagination
- fix argument order when filtering members by properties or email

## Testing
- `php -l perch/addons/apps/perch_members/modes/members.list.pre.php`
- `php -l perch/addons/apps/perch_members/PerchMembers_Members.class.php`


------
https://chatgpt.com/codex/tasks/task_b_68c2a75f09e48324a5df68181bf15bec