### PR TITLE
Define group property on PerchXMLTag

### DIFF
--- a/perch/core/lib/PerchXMLTag.class.php
+++ b/perch/core/lib/PerchXMLTag.class.php
@@ -4,6 +4,14 @@
     {
         public $attributes      = [];
         public $data_attributes = [];
+        /**
+         * Holds group information when tags are grouped within templates.
+         *
+         * PHP 8.2 deprecates dynamic properties, so we explicitly define this
+         * property to avoid "Creation of dynamic property" warnings when the
+         * template parser sets $Tag->group during group annotation.
+         */
+        public $group = false;
         private $tag;
         
         public function __construct($tag, $boolean_attributes = true)

--- a/perch/coreperchdev/lib/PerchXMLTag.class.php
+++ b/perch/coreperchdev/lib/PerchXMLTag.class.php
@@ -4,6 +4,12 @@
     {
         public $attributes      = [];
         public $data_attributes = [];
+        /**
+         * Explicitly defined group property used when annotating tags with
+         * grouping information. Defining the property avoids PHP 8.2 warnings
+         * about creating dynamic properties at runtime.
+         */
+        public $group = false;
         private $tag;
         
         public function __construct($tag, $boolean_attributes = true)


### PR DESCRIPTION
## Summary
- Define `group` property on `PerchXMLTag` to prevent PHP 8.2 dynamic property warnings when using `perch:group`

## Testing
- `php -l perch/core/lib/PerchXMLTag.class.php`
- `php -l perch/coreperchdev/lib/PerchXMLTag.class.php`


------
https://chatgpt.com/codex/tasks/task_b_68c436ed534c832485d8d486e42fa9ca