### PR TITLE
Validate JSON input for AI content generation

### DIFF
--- a/perch/core/apps/content/ai/generate.php
+++ b/perch/core/apps/content/ai/generate.php
@@ -2,6 +2,10 @@
 require_once __DIR__ . '/../PerchContent_AI.class.php';
 
 $input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    echo json_encode(['content' => 'Invalid request']);
+    exit;
+}
 $prompt = isset($input['prompt']) ? $input['prompt'] : '';
 
 $ai = new PerchContent_AI();


### PR DESCRIPTION
## Summary
- Ensure AI content generator gracefully handles invalid JSON input by returning error message.

## Testing
- `php -l perch/core/apps/content/ai/generate.php`

------
https://chatgpt.com/codex/tasks/task_b_68c8318f2cc483248f6be8f49b1d29ed