### PR TITLE
Make OpenAI API key configurable

### DIFF
--- a/perch/config/config.php
+++ b/perch/config/config.php
@@ -30,7 +30,9 @@
     define('PERCH_DEBUG', true);
    define('PERCH_STRIPSLASHES', false);
    define('PERCH_TWILLIO_AUTHTOKEN', "");
-   define('OPENAI_API_KEY',"");
+   if (!defined('OPENAI_API_KEY')) {
+       define('OPENAI_API_KEY', getenv('OPENAI_API_KEY') ?: '');
+   }
 define('PERCH_EMAIL_METHOD', 'smtp');
 define('PERCH_EMAIL_HOST', 'sandbox.smtp.mailtrap.io');
 define('PERCH_EMAIL_AUTH', true);

--- a/perch/core/apps/content/PerchContent_AI.class.php
+++ b/perch/core/apps/content/PerchContent_AI.class.php
@@ -3,9 +3,15 @@ class PerchContent_AI
 {
     private $api_key;
 
-    public function __construct()
+    public function __construct($api_key = null)
     {
-         $this->api_key = OPENAI_API_KEY;
+        if ($api_key !== null) {
+            $this->api_key = $api_key;
+        } elseif (defined('OPENAI_API_KEY')) {
+            $this->api_key = OPENAI_API_KEY;
+        } else {
+            $this->api_key = '';
+        }
     }
 
     public function generate($prompt)

--- a/perch/core/apps/content/ai/generate.php
+++ b/perch/core/apps/content/ai/generate.php
@@ -14,12 +14,7 @@ if (!is_array($input)) {
 }
 $prompt = isset($input['prompt']) ? $input['prompt'] : '';
 
-    if (!defined('OPENAI_API_KEY') || !OPENAI_API_KEY) {
-        $env_key = getenv('OPENAI_API_KEY');
-        if ($env_key) {
-            define('OPENAI_API_KEY', $env_key);
-        }
-    }
+    $api_key = defined('OPENAI_API_KEY') ? OPENAI_API_KEY : getenv('OPENAI_API_KEY');
     if (!class_exists('PerchUtil')) {
         include_once PERCH_CORE . '/lib/PerchUtil.class.php';
     }
@@ -30,7 +25,7 @@ $prompt = isset($input['prompt']) ? $input['prompt'] : '';
     $input  = json_decode(file_get_contents('php://input'), true);
     $prompt = isset($input['prompt']) ? $input['prompt'] : '';
 
-    $ai      = new PerchContent_AI();
+    $ai      = new PerchContent_AI($api_key);
     $content = $ai->generate($prompt);
 
     echo json_encode(['content' => $content]);


### PR DESCRIPTION
## Summary
- load the OpenAI API key from the environment when the constant is undefined
- pass the resolved API key into the AI content generator instead of relying on global state
- allow `PerchContent_AI` to accept an injected API key while falling back to the constant

## Testing
- `php -l perch/config/config.php`
- `php -l perch/core/apps/content/ai/generate.php`
- `php -l perch/core/apps/content/PerchContent_AI.class.php`


------
https://chatgpt.com/codex/tasks/task_b_68c83e4a8584832483f73260f6e3fdea