### PR TITLE
Replace deprecated PHP functions

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Products.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Products.class.php
@@ -215,17 +215,15 @@ class PerchShop_Products extends PerchShop_Factory
 		return [];
 	}
 
-	private function array_flatten($arr) 
-	{
-	    $arr = array_values($arr);
-	    while (list($k,$v)=each($arr)) {
-	        if (is_array($v)) {
-	            array_splice($arr,$k,1,$v);
-	            next($arr);
-	        }
-	    }
-	    return $arr;
-	}
+        private function array_flatten($arr)
+        {
+            $result = [];
+            array_walk_recursive($arr, function ($value) use (&$result) {
+                $result[] = $value;
+            });
+
+            return $result;
+        }
 
 
 

--- a/perch/addons/apps/perch_shop/lib/vendor/braintree/braintree_php/lib/Braintree/Util.php
+++ b/perch/addons/apps/perch_shop/lib/vendor/braintree/braintree_php/lib/Braintree/Util.php
@@ -207,7 +207,9 @@ class Util
         // every time this function is called.
         static $callback = null;
         if ($callback === null) {
-            $callback = create_function('$matches', 'return strtoupper($matches[1]);');
+            $callback = function ($matches) {
+                return strtoupper($matches[1]);
+            };
         }
 
         return preg_replace_callback('/' . $delimiter . '(\w)/', $callback, $string);

--- a/perch/core/lib/PHPMailer.class.php
+++ b/perch/core/lib/PHPMailer.class.php
@@ -2695,30 +2695,17 @@ class PHPMailer
             if (!is_readable($path)) {
                 throw new phpmailerException($this->lang('file_open') . $path, self::STOP_CONTINUE);
             }
-            if(function_exists( 'get_magic_quotes_runtime' )){
-            $magic_quotes = get_magic_quotes_runtime();
-            }else{
-             $magic_quotes = false;
-            }
-
-            if ($magic_quotes) {
-                if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+                        $magic_quotes = false;
+            if (function_exists('get_magic_quotes_runtime') && function_exists('set_magic_quotes_runtime')) {
+                $magic_quotes = get_magic_quotes_runtime();
+                if ($magic_quotes) {
                     set_magic_quotes_runtime(false);
-                } else {
-                    //Doesn't exist in PHP 5.4, but we don't need to check because
-                    //get_magic_quotes_runtime always returns false in 5.4+
-                    //so it will never get here
-                    ini_set('magic_quotes_runtime', false);
                 }
             }
             $file_buffer = file_get_contents($path);
             $file_buffer = $this->encodeString($file_buffer, $encoding);
-            if ($magic_quotes) {
-                if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-                    set_magic_quotes_runtime($magic_quotes);
-                } else {
-                    ini_set('magic_quotes_runtime', $magic_quotes);
-                }
+            if ($magic_quotes && function_exists('set_magic_quotes_runtime')) {
+                set_magic_quotes_runtime($magic_quotes);
             }
             return $file_buffer;
         } catch (Exception $exc) {

--- a/perch/core/lib/PerchDB_MySQL.class.php
+++ b/perch/core/lib/PerchDB_MySQL.class.php
@@ -371,45 +371,33 @@ class PerchDB_MySQL
 
 
 	public function pdb($value)
-	{
+        {
 
+                // Stripslashes
+                $value = PerchUtil::safe_stripslashes($value);
 
-         if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-               set_magic_quotes_runtime(false);
-         } else {
-                        //Doesn't exist in PHP 5.4, but we don't need to check because
-                        //get_magic_quotes_runtime always returns false in 5.4+
-                        //so it will never get here
-           ini_set('magic_quotes_runtime', false);
-      }
+                $link = $this->get_link();
+            if (!$link) return false;
 
+                // Quote
+                switch(gettype($value)) {
+                        case 'integer':
+                        case 'double':
+                                $escape = $value;
+                                break;
+                        case 'string':
+                                $escape = $link->quote($value);
+                                break;
+                        case 'NULL':
+                                $escape = 'NULL';
+                                break;
+                        default:
+                                $escape = $link->quote($value);
+                }
 
-		// Stripslashes
-		//if (function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime()) {
-			$value = PerchUtil::safe_stripslashes($value);
-		//}
+                return $escape;
+        }
 
-		$link = $this->get_link();
-	    if (!$link) return false;
-
-		// Quote
-		switch(gettype($value)) {
-			case 'integer':
-			case 'double':
-				$escape = $value;
-				break;
-			case 'string':
-				$escape = $link->quote($value);
-				break;
-			case 'NULL':
-				$escape = 'NULL';
-				break;
-			default:
-				$escape = $link->quote($value);
-		}
-
-		return $escape;
-	}
 
 	public function get_table_meta($table)
 	{

--- a/perch/core/lib/PerchUtil.class.php
+++ b/perch/core/lib/PerchUtil.class.php
@@ -296,39 +296,41 @@
 		}
 
 		public static function is_valid_email($email)
-		{
-			if (function_exists('filter_var')) {
-				return filter_var($email, FILTER_VALIDATE_EMAIL);
-			} else {
+                {
+                        if (function_exists('filter_var')) {
+                                return filter_var($email, FILTER_VALIDATE_EMAIL);
+                        }
 
-				if (!ereg("^[^@]{1,64}@[^@]{1,255}$", $email)) {
-					// Email invalid because wrong number of characters in one section, or wrong number of @ symbols.
-					return false;
-				}
+                        $email_pattern = "/^[^@]{1,64}@[^@]{1,255}$/";
+                        if (preg_match($email_pattern, $email) !== 1) {
+                                // Email invalid because wrong number of characters in one section, or wrong number of @ symbols.
+                                return false;
+                        }
 
-				// Split it into sections to make life easier
-				$email_array = explode("@", $email);
-				$local_array = explode(".", $email_array[0]);
-				for ($i = 0; $i < sizeof($local_array); $i++) {
-					if (!ereg("^(([A-Za-z0-9!#$%&'*+/=?^_`{|}~-][A-Za-z0-9!#$%&'*+/=?^_`{|}~\.-]{0,63})|(\"[^(\\|\")]{0,62}\"))$", $local_array[$i])) {
-						return false;
-					}
-				}
-				if (!ereg("^\[?[0-9\.]+\]?$", $email_array[1])) { // Check if domain is IP. If not, it should be valid domain name
-					$domain_array = explode(".", $email_array[1]);
-					if (sizeof($domain_array) < 2) {
-						return false; // Not enough parts to domain
-					}
-					for ($i = 0; $i < sizeof($domain_array); $i++) {
-						if (!ereg("^(([A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9])|([A-Za-z0-9]+))$", $domain_array[$i])) {
-							return false;
-						}
-					}
-				}
+                        // Split it into sections to make life easier
+                        $email_array = explode("@", $email);
+                        $local_array = explode(".", $email_array[0]);
+                        $local_pattern = "/^(([A-Za-z0-9!#$%&'*+/=?^_`{|}~-][A-Za-z0-9!#$%&'*+/=?^_`{|}~\.-]{0,63})|(\"([^\\\"]){0,62}\"))$/";
+                        foreach ($local_array as $local_part) {
+                                if (preg_match($local_pattern, $local_part) !== 1) {
+                                        return false;
+                                }
+                        }
+                        if (preg_match("/^\\[?[0-9\.]+\\]?$/", $email_array[1]) !== 1) { // Check if domain is IP. If not, it should be valid domain name
+                                $domain_array = explode(".", $email_array[1]);
+                                if (sizeof($domain_array) < 2) {
+                                        return false; // Not enough parts to domain
+                                }
+                                $domain_pattern = "/^(([A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9])|([A-Za-z0-9]+))$/";
+                                foreach ($domain_array as $domain_part) {
+                                        if (preg_match($domain_pattern, $domain_part) !== 1) {
+                                                return false;
+                                        }
+                                }
+                        }
 
-				return true;
-			}
-		}
+                        return true;
+                }
 
 		public static function excerpt($str, $words, $strip_tags = true, $balance_tags = false, $append = false)
 		{
@@ -1384,38 +1386,18 @@
 		}
 
 		public static function safe_stripslashes($str)
-		{
-			$strip = false;
-			//  if (!defined('PERCH_STRIPSLASHES'))         define('PERCH_STRIPSLASHES', false);
-			if (PERCH_STRIPSLASHES) {
-				$strip = true;
-			}
-			/*if (function_exists( 'get_magic_quotes_gpc' ) && get_magic_quotes_gpc()) {
-				$strip = true;
-			}*/
+                {
+                        $strip = false;
+                        if (PERCH_STRIPSLASHES) {
+                                $strip = true;
+                        }
 
+                        if ($strip) {
+                                return stripslashes($str);
+                        }
 
-
-                if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-                    set_magic_quotes_runtime(false);
-                } else {
-                   //Doesn't exist in PHP 5.4, but we don't need to check because
-                   //get_magic_quotes_runtime always returns false in 5.4+
-                   //so it will never get here
-                   ini_set('magic_quotes_runtime', false);
+                        return $str;
                 }
-
-
-
-			/*if (function_exists( 'get_magic_quotes_runtime' )) {
-				$strip = true;
-			}*/
-			if ($strip) {
-				return stripslashes($str);
-			}
-
-			return $str;
-		}
 
 		public static function flush_output()
 		{

--- a/perch/coreperchdev/lib/PHPMailer.class.php
+++ b/perch/coreperchdev/lib/PHPMailer.class.php
@@ -2695,30 +2695,17 @@ class PHPMailer
             if (!is_readable($path)) {
                 throw new phpmailerException($this->lang('file_open') . $path, self::STOP_CONTINUE);
             }
-            if(function_exists( 'get_magic_quotes_runtime' )){
-            $magic_quotes = get_magic_quotes_runtime();
-            }else{
-             $magic_quotes = false;
-            }
-
-            if ($magic_quotes) {
-                if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+                        $magic_quotes = false;
+            if (function_exists('get_magic_quotes_runtime') && function_exists('set_magic_quotes_runtime')) {
+                $magic_quotes = get_magic_quotes_runtime();
+                if ($magic_quotes) {
                     set_magic_quotes_runtime(false);
-                } else {
-                    //Doesn't exist in PHP 5.4, but we don't need to check because
-                    //get_magic_quotes_runtime always returns false in 5.4+
-                    //so it will never get here
-                    ini_set('magic_quotes_runtime', false);
                 }
             }
             $file_buffer = file_get_contents($path);
             $file_buffer = $this->encodeString($file_buffer, $encoding);
-            if ($magic_quotes) {
-                if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-                    set_magic_quotes_runtime($magic_quotes);
-                } else {
-                    ini_set('magic_quotes_runtime', $magic_quotes);
-                }
+            if ($magic_quotes && function_exists('set_magic_quotes_runtime')) {
+                set_magic_quotes_runtime($magic_quotes);
             }
             return $file_buffer;
         } catch (Exception $exc) {

--- a/perch/coreperchdev/lib/PerchDB_MySQL.class.php
+++ b/perch/coreperchdev/lib/PerchDB_MySQL.class.php
@@ -372,45 +372,33 @@ class PerchDB_MySQL
 
 
 	public function pdb($value)
-	{
+        {
 
+                // Stripslashes
+                $value = PerchUtil::safe_stripslashes($value);
 
-         if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-               set_magic_quotes_runtime(false);
-         } else {
-                        //Doesn't exist in PHP 5.4, but we don't need to check because
-                        //get_magic_quotes_runtime always returns false in 5.4+
-                        //so it will never get here
-           ini_set('magic_quotes_runtime', false);
-      }
+                $link = $this->get_link();
+            if (!$link) return false;
 
+                // Quote
+                switch(gettype($value)) {
+                        case 'integer':
+                        case 'double':
+                                $escape = $value;
+                                break;
+                        case 'string':
+                                $escape = $link->quote($value);
+                                break;
+                        case 'NULL':
+                                $escape = 'NULL';
+                                break;
+                        default:
+                                $escape = $link->quote($value);
+                }
 
-		// Stripslashes
-		//if (function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime()) {
-			$value = PerchUtil::safe_stripslashes($value);
-		//}
+                return $escape;
+        }
 
-		$link = $this->get_link();
-	    if (!$link) return false;
-
-		// Quote
-		switch(gettype($value)) {
-			case 'integer':
-			case 'double':
-				$escape = $value;
-				break;
-			case 'string':
-				$escape = $link->quote($value);
-				break;
-			case 'NULL':
-				$escape = 'NULL';
-				break;
-			default:
-				$escape = $link->quote($value);
-		}
-
-		return $escape;
-	}
 
 	public function get_table_meta($table)
 	{

--- a/perch/coreperchdev/lib/PerchUtil.class.php
+++ b/perch/coreperchdev/lib/PerchUtil.class.php
@@ -296,39 +296,41 @@
 		}
 
 		public static function is_valid_email($email)
-		{
-			if (function_exists('filter_var')) {
-				return filter_var($email, FILTER_VALIDATE_EMAIL);
-			} else {
+                {
+                        if (function_exists('filter_var')) {
+                                return filter_var($email, FILTER_VALIDATE_EMAIL);
+                        }
 
-				if (!ereg("^[^@]{1,64}@[^@]{1,255}$", $email)) {
-					// Email invalid because wrong number of characters in one section, or wrong number of @ symbols.
-					return false;
-				}
+                        $email_pattern = "/^[^@]{1,64}@[^@]{1,255}$/";
+                        if (preg_match($email_pattern, $email) !== 1) {
+                                // Email invalid because wrong number of characters in one section, or wrong number of @ symbols.
+                                return false;
+                        }
 
-				// Split it into sections to make life easier
-				$email_array = explode("@", $email);
-				$local_array = explode(".", $email_array[0]);
-				for ($i = 0; $i < sizeof($local_array); $i++) {
-					if (!ereg("^(([A-Za-z0-9!#$%&'*+/=?^_`{|}~-][A-Za-z0-9!#$%&'*+/=?^_`{|}~\.-]{0,63})|(\"[^(\\|\")]{0,62}\"))$", $local_array[$i])) {
-						return false;
-					}
-				}
-				if (!ereg("^\[?[0-9\.]+\]?$", $email_array[1])) { // Check if domain is IP. If not, it should be valid domain name
-					$domain_array = explode(".", $email_array[1]);
-					if (sizeof($domain_array) < 2) {
-						return false; // Not enough parts to domain
-					}
-					for ($i = 0; $i < sizeof($domain_array); $i++) {
-						if (!ereg("^(([A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9])|([A-Za-z0-9]+))$", $domain_array[$i])) {
-							return false;
-						}
-					}
-				}
+                        // Split it into sections to make life easier
+                        $email_array = explode("@", $email);
+                        $local_array = explode(".", $email_array[0]);
+                        $local_pattern = "/^(([A-Za-z0-9!#$%&'*+/=?^_`{|}~-][A-Za-z0-9!#$%&'*+/=?^_`{|}~\.-]{0,63})|(\"([^\\\"]){0,62}\"))$/";
+                        foreach ($local_array as $local_part) {
+                                if (preg_match($local_pattern, $local_part) !== 1) {
+                                        return false;
+                                }
+                        }
+                        if (preg_match("/^\\[?[0-9\.]+\\]?$/", $email_array[1]) !== 1) { // Check if domain is IP. If not, it should be valid domain name
+                                $domain_array = explode(".", $email_array[1]);
+                                if (sizeof($domain_array) < 2) {
+                                        return false; // Not enough parts to domain
+                                }
+                                $domain_pattern = "/^(([A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9])|([A-Za-z0-9]+))$/";
+                                foreach ($domain_array as $domain_part) {
+                                        if (preg_match($domain_pattern, $domain_part) !== 1) {
+                                                return false;
+                                        }
+                                }
+                        }
 
-				return true;
-			}
-		}
+                        return true;
+                }
 
 		public static function excerpt($str, $words, $strip_tags = true, $balance_tags = false, $append = false)
 		{
@@ -1384,38 +1386,18 @@
 		}
 
 		public static function safe_stripslashes($str)
-		{
-			$strip = false;
-			//  if (!defined('PERCH_STRIPSLASHES'))         define('PERCH_STRIPSLASHES', false);
-			if (PERCH_STRIPSLASHES) {
-				$strip = true;
-			}
-			/*if (function_exists( 'get_magic_quotes_gpc' ) && get_magic_quotes_gpc()) {
-				$strip = true;
-			}*/
+                {
+                        $strip = false;
+                        if (PERCH_STRIPSLASHES) {
+                                $strip = true;
+                        }
 
+                        if ($strip) {
+                                return stripslashes($str);
+                        }
 
-
-                if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-                    set_magic_quotes_runtime(false);
-                } else {
-                   //Doesn't exist in PHP 5.4, but we don't need to check because
-                   //get_magic_quotes_runtime always returns false in 5.4+
-                   //so it will never get here
-                   ini_set('magic_quotes_runtime', false);
+                        return $str;
                 }
-
-
-
-			/*if (function_exists( 'get_magic_quotes_runtime' )) {
-				$strip = true;
-			}*/
-			if ($strip) {
-				return stripslashes($str);
-			}
-
-			return $str;
-		}
 
 		public static function flush_output()
 		{


### PR DESCRIPTION
## Summary
- replace the legacy `ereg` email validation fallback with PCRE checks and simplify `safe_stripslashes()` in both PerchUtil libraries
- remove runtime magic quotes handling from the MySQL helper and PHPMailer wrappers to avoid deprecated APIs
- modernize Perch Shop helpers by replacing `each()` and `create_function()` with supported alternatives

## Testing
- php -l perch/core/lib/PerchUtil.class.php
- php -l perch/coreperchdev/lib/PerchUtil.class.php
- php -l perch/core/lib/PerchDB_MySQL.class.php
- php -l perch/coreperchdev/lib/PerchDB_MySQL.class.php
- php -l perch/core/lib/PHPMailer.class.php
- php -l perch/coreperchdev/lib/PHPMailer.class.php
- php -l perch/addons/apps/perch_shop/lib/PerchShop_Products.class.php
- php -l perch/addons/apps/perch_shop/lib/vendor/braintree/braintree_php/lib/Braintree/Util.php

------
https://chatgpt.com/codex/tasks/task_b_68c959701438832494523d2a390c5a8b