### PR TITLE
Improve page translation workflow

### DIFF
--- a/perch/core/apps/content/PerchContent_Regions.class.php
+++ b/perch/core/apps/content/PerchContent_Regions.class.php
@@ -71,27 +71,31 @@ class PerchContent_Regions extends PerchFactory
         $sort_dir = null;
 
 
-        $sql = 'SELECT';
+        $lang = trim($lang);
+        $suffix = ' - '.$lang;
 
-        $sql .= ' * FROM '.$this->table.' WHERE TRIM(regionKey) NOT REGEXP " - .{2}$" and pageID='.$this->db->pdb((int)$pageID);
+        $sql  = 'SELECT base.* FROM '.$this->table.' base';
+        $sql .= ' LEFT JOIN '.$this->table.' translated ON translated.pageID=base.pageID';
+        $sql .= ' AND translated.regionKey=CONCAT(base.regionKey, '.$this->db->pdb($suffix).')';
+        $sql .= ' WHERE base.pageID='.$this->db->pdb((int)$pageID);
+        $sql .= ' AND (base.language='.$this->db->pdb('*').' OR base.language='.$this->db->pdb('').' OR base.language IS NULL)';
 
         if (!$include_shared) {
-            $sql .= ' AND regionPage!='.$this->db->pdb('*');
+            $sql .= ' AND base.regionPage!='.$this->db->pdb('*');
         }
 
+        if ($new_only) {
+            $sql .= ' AND base.regionNew=1';
+        }
 
+        if ($template) {
+            $sql .= ' AND base.regionTemplate='.$this->db->pdb($template).' ';
+        }
 
-		if ($template) {
-			$sql .= ' AND regionTemplate='.$this->db->pdb($template).' ';
-		}
-
-
-
-
+        $sql .= ' AND translated.regionID IS NULL';
+        $sql .= ' ORDER BY base.regionOrder ASC';
 
         $rows = $this->db->get_rows($sql);
-
-
 
         return $this->return_instances($rows);
     }
@@ -104,7 +108,7 @@ class PerchContent_Regions extends PerchFactory
      * @return void
      * @author Drew McLellan
      */
-    public function get_for_page($pageID, $include_shared=true, $new_only=false, $template=false, PerchAPI_Paging $Paging = null)
+    public function get_for_page($pageID, $include_shared=true, $new_only=false, $template=false, PerchAPI_Paging $Paging = null, $language=false)
     {
         if ($this->_regions_preloaded) {
             if (isset($this->_region_cache[$pageID])) {
@@ -123,23 +127,31 @@ class PerchContent_Regions extends PerchFactory
         }
         
         $sql .= ' * FROM '.$this->table.' WHERE pageID='.$this->db->pdb((int)$pageID);
-        
+
         if (!$include_shared) {
             $sql .= ' AND regionPage!='.$this->db->pdb('*');
         }
 
-		if ($new_only) {
-			$sql .= ' AND regionNew=1 ';
-		}
-        
-		if ($template) {
-			$sql .= ' AND regionTemplate='.$this->db->pdb($template).' ';
-		}
+                if ($new_only) {
+                        $sql .= ' AND regionNew=1 ';
+                }
+
+                if ($template) {
+                        $sql .= ' AND regionTemplate='.$this->db->pdb($template).' ';
+                }
+
+        if ($language !== false && $language !== '') {
+            $language = trim($language);
+            $language_condition = 'language='.$this->db->pdb($language);
+            $language_condition .= ' OR ((language='.$this->db->pdb('*').' OR language='.$this->db->pdb('').' OR language IS NULL)';
+            $language_condition .= ' AND regionKey LIKE '.$this->db->pdb('% - '.$language).')';
+            $sql .= ' AND ('.$language_condition.')';
+        }
 
         if ($Paging && $Paging->enabled() && $sort_val) {
             $sql .= ' ORDER BY '.$sort_val.' '.$sort_dir;
         } else {
-            $sql .= ' ORDER BY regionOrder ASC';    
+            $sql .= ' ORDER BY regionOrder ASC';
         }
         
         if ($Paging && $Paging->enabled()) {

--- a/perch/core/apps/content/modes/page.edit.post.php
+++ b/perch/core/apps/content/modes/page.edit.post.php
@@ -28,9 +28,9 @@
             ]); 
          $Smartbar->add_item([
                 'title'  => 'Translate Page',
-                'link'   => '/core/apps/content/page/url/?id='.$Page->id(),
+                'link'   => '/core/apps/content/page/translate/?id='.$Page->id(),
                 'priv'   => 'content.pages.translate',
-                'icon'   => 'core/o-signs',
+                'icon'   => 'core/lang',
             ]);
 
             $Smartbar->add_item([

--- a/perch/core/apps/content/modes/page.post.php
+++ b/perch/core/apps/content/modes/page.post.php
@@ -42,7 +42,7 @@
                 'title'  => 'Translate Page',
                 'link'   => '/core/apps/content/page/translate/?id='.$Page->id(),
                 'priv'   => 'content.pages.translate',
-                'icon'   => 'core/o-signs',
+                'icon'   => 'core/lang',
             ]);
 
 			$Smartbar->add_item([

--- a/perch/core/apps/content/modes/page.pre.php
+++ b/perch/core/apps/content/modes/page.pre.php
@@ -15,9 +15,10 @@
           $tags = $Languages->find_all();
 
 
+    $lang = false;
     if (isset($_GET['lang']) && $_GET['lang'] != '') {
         $filter = 'lang';
-        $lang = $_GET['lang'];
+        $lang = trim($_GET['lang']);
 
     }
 
@@ -52,7 +53,7 @@
 	if ($Page->pagePath()=='*') {
         $regions = $Regions->get_shared($Paging);
     }else{
-        $regions = $Regions->get_for_page($Page->id(), $include_shared=false, $new_only=false, $template=false, $Paging);
+        $regions = $Regions->get_for_page($Page->id(), $include_shared=false, $new_only=false, $template=false, $Paging, $lang);
     }
 
 

--- a/perch/core/apps/content/modes/page.translate.post.php
+++ b/perch/core/apps/content/modes/page.translate.post.php
@@ -1,48 +1,78 @@
 <?php
+    echo $HTML->title_panel([
+        'heading' => sprintf(PerchLang::get('Translate %s Page'), ' &#8216;' . PerchUtil::html($Page->pageNavText()) . '&#8217; '),
+    ]);
 
-	    echo $HTML->title_panel([
-            'heading' => sprintf(PerchLang::get('Transalte %s Page'),' &#8216;' . PerchUtil::html($Page->pageNavText()) . '&#8217; ')
-            ]);
-?>
-    <form method="post" action="<?php echo PerchUtil::html($Form->action()); ?>" class="form-simple">
-<?php
+    $Smartbar = new PerchSmartbar($CurrentUser, $HTML, $Lang);
+    $Smartbar->add_item([
+        'title'  => 'Regions',
+        'link'   => '/core/apps/content/page/?id='.$Page->id(),
+        'icon'   => 'core/o-grid',
+    ]);
 
-                    echo '<h2 class="divider"><div>'.PerchLang::get('Languages').'</div></h2>';
-              ?>
-
-
-   <div class="field-wrap">
-            <?php echo $Form->label('lang', 'Transalte page to'); ?>
-            <div class="form-entry">
-            <?php
-                  $langs=[];
-                                              	if (PerchUtil::count($details)) {
-                                              			foreach($details as $row) {
-
-                                                               array_push($langs,$row->lang());
-
-                                              			}
-                                              			}
-
-                                   $opts = array();
-                                  if (!$vals) $vals = array();
-
-                                   if (PerchUtil::count($details)) {
-                                       foreach($details as $row) {
-
-                                           $opts[] = array('label'=>$row->lang(), 'value'=>$row->lang());
-                                       }
-                                   }
-              echo $Form->select('lang', $opts, $val);
-               echo $Form->checkbox_set('web_languages', 'Languages',  $opts,  $vals, $class='', $limit=false);
-
-            ?>
-            </div>
-        </div>
-       <?php
-
-    echo $HTML->submit_bar([
-        'button' =>$Form->submit('btnsubmit', 'Submit')
+    if ($Page->pagePath() != '*') {
+        $Smartbar->add_item([
+            'title'  => 'Details',
+            'link'   => '/core/apps/content/page/details/?id='.$Page->id(),
+            'priv'   => 'content.pages.attributes',
+            'icon'   => 'core/o-toggles',
         ]);
-?>
-    </form>
+
+        $Smartbar->add_item([
+            'title'  => 'Location',
+            'link'   => '/core/apps/content/page/url/?id='.$Page->id(),
+            'priv'   => 'content.pages.manage_urls',
+            'icon'   => 'core/o-signs',
+        ]);
+
+        $Smartbar->add_item([
+            'active' => true,
+            'title'  => 'Translate Page',
+            'link'   => '/core/apps/content/page/translate/?id='.$Page->id(),
+            'priv'   => 'content.pages.translate',
+            'icon'   => 'core/lang',
+        ]);
+
+        $Smartbar->add_item([
+            'title'         => 'View Page',
+            'link'          => rtrim($Settings->get('siteURL')->val(), '/').$Page->pagePath(),
+            'icon'          => 'core/document',
+            'position'      => 'end',
+            'new-tab'       => true,
+            'link-absolute' => true,
+        ]);
+
+        $Smartbar->add_item([
+            'title'    => 'Settings',
+            'link'     => '/core/apps/content/page/edit/?id='.$Page->id(),
+            'priv'     => 'content.pages.edit',
+            'icon'     => 'core/gear',
+            'position' => 'end',
+        ]);
+    }
+
+    echo $Smartbar->render();
+
+    $Alert->output();
+
+    if ($form_disabled) {
+        echo '<div class="inner">';
+        echo '<p>'.PerchLang::get('There are no additional languages available for this page.').'</p>';
+        echo '</div>';
+    } else {
+        echo $Form->form_start();
+
+        echo '<h2 class="divider"><div>'.PerchLang::get('Languages').'</div></h2>';
+        echo '<div class="field-wrap">';
+        echo $Form->label('lang', PerchLang::get('Translate page to'));
+        echo '<div class="form-entry">';
+        echo $Form->select('lang', $lang_options, $Form->get($form_defaults, 'lang'));
+        echo '</div>';
+        echo '</div>';
+
+        echo $HTML->submit_bar([
+            'button' => $Form->submit('btnsubmit', PerchLang::get('Create translation'), 'button'),
+        ]);
+
+        echo $Form->form_end();
+    }

--- a/perch/core/apps/content/modes/page.translate.pre.php
+++ b/perch/core/apps/content/modes/page.translate.pre.php
@@ -3,44 +3,142 @@
     $Lang   = $API->get('Lang');
     $HTML   = $API->get('HTML');
 
+    $Pages     = new PerchContent_Pages();
+    $Regions   = new PerchContent_Regions();
+    $Languages = new PerchContent_Languages();
+    $Page      = false;
 
-    $Pages = new PerchContent_Pages;
-    $Regions = new PerchContent_Regions;
-    $Page  = false;
+    $language_list = $Languages->find_all();
 
-        $Languages    = new PerchContent_Languages;
-          $details = $Languages->find_all();
+    if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+        $id   = (int) $_GET['id'];
+        $Page = $Pages->find($id);
+    }
 
+    if (!$Page || !is_object($Page)) {
+        PerchUtil::redirect(PERCH_LOGINPATH . '/core/apps/content/');
+    }
 
-        // Find the page
-        if (isset($_GET['id']) && is_numeric($_GET['id'])) {
-            $id = (int) $_GET['id'];
-            $Page = $Pages->find($id);
+    if (!$CurrentUser->has_priv('content.pages.translate')) {
+        PerchUtil::redirect(PERCH_LOGINPATH . '/core/apps/content/');
+    }
+
+    $Form = $API->get('Form');
+
+    $lang_options               = [];
+    $available_language_values  = [];
+    $existing_languages         = [];
+    $form_defaults              = [];
+    $selected_lang              = '';
+    $form_disabled              = false;
+
+    $language_codes = [];
+    if (PerchUtil::count($language_list)) {
+        foreach ($language_list as $Language) {
+            $language_codes[] = $Language->lang();
+        }
+    }
+
+    if (!PerchUtil::count($language_codes)) {
+        $form_disabled = true;
+        $Alert->set('notice', PerchLang::get('Enable page languages before creating translations.'));
+    }
+
+    if (!$form_disabled) {
+        $page_regions = $Regions->get_for_page($Page->id());
+        if (PerchUtil::count($page_regions)) {
+            foreach ($page_regions as $Region) {
+                $region_lang = $Region->language();
+                if ($region_lang && $region_lang !== '*' && $region_lang !== '') {
+                    $existing_languages[$region_lang] = true;
+                    continue;
+                }
+
+                if (preg_match('/^(.*) - ([A-Za-z0-9_\\-]+)$/', $Region->regionKey(), $matches)) {
+                    $base_key      = $matches[1];
+                    $possible_lang = $matches[2];
+
+                    if (in_array($possible_lang, $language_codes, true)) {
+                        $BaseRegion = $Regions->find_for_page_by_key($Page->id(), $base_key);
+                        if ($BaseRegion) {
+                            if ($region_lang === '*' || $region_lang === '' || $region_lang === false) {
+                                $Region->update(['language' => $possible_lang]);
+                                $region_lang = $possible_lang;
+                            }
+                            $existing_languages[$possible_lang] = true;
+                        }
+                    }
+                }
+            }
         }
 
-          $Form = new PerchForm('translatepage');
-  if ($Form->posted() ) {
-  $postvars = array('lang');
+        if (PerchUtil::count($language_list)) {
+            foreach ($language_list as $Language) {
+                $code  = $Language->lang();
+                $label = $Language->name();
+                if ($label == '') $label = $code;
 
+                if (!isset($existing_languages[$code])) {
+                    $lang_options[] = [
+                        'label' => $label,
+                        'value' => $code,
+                    ];
+                }
+            }
+        }
 
+        if (!PerchUtil::count($lang_options)) {
+            $form_disabled = true;
+            $Alert->set('info', PerchLang::get('Translations already exist for all configured languages.'));
+        } else {
+            foreach ($lang_options as $opt) {
+                $available_language_values[] = $opt['value'];
+            }
+        }
+    }
 
-      	$data = $Form->receive($postvars);
-      	//print_r($data);
-      	$lang=$data["lang"];
-      	$regions=$Regions->get_for_translation_page($lang,$id);
+    if (!$form_disabled) {
+        $Form->set_required([
+            'lang' => 'Required',
+        ]);
+    }
 
-      		foreach($regions as $region) {
-$newregionKey=$region->regionKey()." - ".$lang;
-                              // 	print_r($newregionKey);
-                               	$data=$region->to_array();
-                               	unset(	$data["regionID"]);
-                               	$data["regionKey"]=$newregionKey;
-                               	 	//print_r($data);
-                               	 $region->duplicate_region($data);
+    if ($Form->posted() && !$form_disabled && $Form->validate()) {
+        $data = $Form->receive(['lang']);
+        $selected_lang = trim($data['lang']);
+        $form_defaults['lang'] = $selected_lang;
 
-                               //	exit;
+        if ($selected_lang === '' || !in_array($selected_lang, $available_language_values, true)) {
+            $Alert->set('error', PerchLang::get('Please select a valid language.'));
+        } else {
+            $regions_to_duplicate = $Regions->get_for_translation_page($selected_lang, $Page->id());
+            if (!PerchUtil::count($regions_to_duplicate)) {
+                $Alert->set('info', PerchLang::get('All regions already have a %s translation.', PerchUtil::html($selected_lang)));
+            } else {
+                $created = false;
 
-	}
-    	       // PerchUtil::redirect(PERCH_LOGINPATH.'/core/apps/content/page/?id='.$id);
+                foreach ($regions_to_duplicate as $Region) {
+                    $data = $Region->to_array();
+                    unset($data['regionID']);
 
-  }
+                    $data['regionKey'] = $Region->regionKey() . ' - ' . $selected_lang;
+                    $data['language']  = $selected_lang;
+                    $data['regionNew'] = 1;
+
+                    $Region->duplicate_region($data);
+                    $created = true;
+                }
+
+                if ($created) {
+                    PerchUtil::redirect(PERCH_LOGINPATH . '/core/apps/content/page/translate/?id=' . $Page->id() . '&created=' . urlencode($selected_lang));
+                } else {
+                    $Alert->set('info', PerchLang::get('All regions already have a %s translation.', PerchUtil::html($selected_lang)));
+                }
+            }
+        }
+    }
+
+    if (PerchUtil::get('created')) {
+        $created_lang = PerchUtil::get('created');
+        $Alert->set('success', PerchLang::get('A %s translation has been created.', PerchUtil::html($created_lang)));
+    }

--- a/perch/core/apps/content/page/translate/index.php
+++ b/perch/core/apps/content/page/translate/index.php
@@ -6,7 +6,7 @@
     include(PERCH_CORE . '/inc/auth.php');
     
     
-    $Perch->page_title = PerchLang::get('Edit Page URL');
+    $Perch->page_title = PerchLang::get('Translate Page');
 
     $app_path = PERCH_CORE.'/apps/content';
     


### PR DESCRIPTION
## Summary
- refresh the translate page workflow to validate selections, avoid duplicate regions, and surface status alerts when creating translations
- modernize the translate page UI with Smartbar navigation and language-specific messaging, plus correct the Smartbar links/icons in related screens
- extend region lookups to skip existing translations and support filtering regions by language when browsing a page

## Testing
- php -l perch/core/apps/content/page/translate/index.php
- php -l perch/core/apps/content/modes/page.translate.pre.php
- php -l perch/core/apps/content/modes/page.translate.post.php
- php -l perch/core/apps/content/PerchContent_Regions.class.php
- php -l perch/core/apps/content/modes/page.pre.php
- php -l perch/core/apps/content/modes/page.edit.post.php
- php -l perch/core/apps/content/modes/page.post.php

------
https://chatgpt.com/codex/tasks/task_b_68d41e4b2c3c832495ddca858b77704c