### PR TITLE
Document translation workflow and extend blog translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,41 @@ Clicking “Generate with AI” opens a prompt dialog where you describe the con
 model to produce. After the request is submitted, Perch retrieves up to 150 tokens of generated text
 and inserts it into the relevant editor field. Always review and edit the suggestion before
 publishing to ensure it matches your tone, house style, and legal obligations.
+
+## Translating Pages and Blog Posts
+
+Perch can duplicate existing content into language-specific drafts so editors can translate pages and
+blog posts without overwriting the original.
+
+### Configure Languages
+
+1. Visit **Settings → Languages** in the control panel.
+2. Add the language codes you need (for example `fr` for French or `es` for Spanish) and save the
+   configuration.
+3. These languages become available throughout the translation tools described below.
+
+### Translate a Page
+
+1. Open the page you want to translate from **Content → Pages** and choose **Translate Page** from the
+   Smartbar.
+2. Select a language from the drop-down list. Existing translations are automatically filtered out so
+   each language can only be created once.
+3. Submit the form to generate new content regions labelled with the language suffix. The regions are
+   created in draft mode so you can edit the translated text before publishing.
+
+### Translate a Blog Post
+
+1. While editing a blog post, choose **Translate Post** from the Smartbar.
+2. Pick a language and click **Create translation**. Perch duplicates the post, marks it as a draft,
+   and appends a language-specific slug so it will not clash with the original.
+3. Use the links in the translation table to jump straight into editing or previewing the new draft.
+
+### Track Translation Progress
+
+The translation screen lists every version of the page or post, including the base content, the
+language assigned to each translation, and quick actions to edit or preview them. Once a translation
+is published it behaves like any other page or post, but the translation dashboard prevents accidental
+duplicates and keeps the workflow organised.
 =======
 # perch
 Replaced the legacy ereg fallback with PCRE-based validation and simplified safe_stripslashes() in both PerchUtil libraries to drop deprecated magic quotes logic.

--- a/perch/addons/apps/perch_blog/lang/en-gb.txt
+++ b/perch/addons/apps/perch_blog/lang/en-gb.txt
@@ -278,5 +278,18 @@
     "Receive webmentions": "Receive webmentions",
     "This comment is a webmention (%s)": "This comment is a webmention (%s)",
     "Comment on \u2018%s\u2019": "Comment on \u2018%s\u2019",
-    "Save & Add another": "Save & Moderate next"
+    "Save & Add another": "Save & Moderate next",
+    "Translate Post": "Translate Post",
+    "Translate %s Post": "Translate \u2018%s\u2019",
+    "Translate post to": "Translate post to",
+    "Please select a valid language.": "Please select a valid language.",
+    "Create translation": "Create translation",
+    "Existing translations": "Existing translations",
+    "Base content": "Base content",
+    "No additional languages are available for this post.": "No additional languages are available for this post.",
+    "Language": "Language",
+    "Languages": "Languages",
+    "Actions": "Actions",
+    "Edit translation": "Edit translation",
+    "Sorry, that translation could not be created.": "Sorry, that translation could not be created."
 }

--- a/perch/addons/apps/perch_blog/lib/PerchBlog_PostTranslation.class.php
+++ b/perch/addons/apps/perch_blog/lib/PerchBlog_PostTranslation.class.php
@@ -1,0 +1,8 @@
+<?php
+
+class PerchBlog_PostTranslation extends PerchAPI_Base
+{
+    protected $table = 'blog_post_translations';
+    protected $pk    = 'translationID';
+}
+

--- a/perch/addons/apps/perch_blog/lib/PerchBlog_PostTranslations.class.php
+++ b/perch/addons/apps/perch_blog/lib/PerchBlog_PostTranslations.class.php
@@ -1,0 +1,77 @@
+<?php
+
+class PerchBlog_PostTranslations extends PerchAPI_Factory
+{
+    protected $table               = 'blog_post_translations';
+    protected $pk                  = 'translationID';
+    protected $singular_classname  = 'PerchBlog_PostTranslation';
+    protected $default_sort_column = 'language';
+
+    public function __construct($api = false)
+    {
+        parent::__construct($api);
+        $this->ensure_table_exists();
+    }
+
+    public function ensure_table_exists()
+    {
+        $sql = 'CREATE TABLE IF NOT EXISTS ' . $this->table . ' (
+            translationID INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+            basePostID INT(10) UNSIGNED NOT NULL,
+            translationPostID INT(10) UNSIGNED NOT NULL,
+            language VARCHAR(16) NOT NULL,
+            created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (translationID),
+            UNIQUE KEY base_lang (basePostID, language),
+            KEY translation_post (translationPostID)
+        ) ENGINE=MyISAM DEFAULT CHARSET=utf8';
+
+        $this->db->execute($sql);
+    }
+
+    public function find_for_post($postID)
+    {
+        $sql = 'SELECT * FROM ' . $this->table . ' WHERE translationPostID=' . $this->db->pdb((int)$postID) . ' LIMIT 1';
+        $row = $this->db->get_row($sql);
+
+        return $this->return_instance($row);
+    }
+
+    public function find_base_id_for_post($postID)
+    {
+        $Translation = $this->find_for_post($postID);
+        if ($Translation && $Translation->basePostID()) {
+            return (int) $Translation->basePostID();
+        }
+
+        return (int) $postID;
+    }
+
+    public function get_for_base($basePostID)
+    {
+        $sql = 'SELECT * FROM ' . $this->table . ' WHERE basePostID=' . $this->db->pdb((int)$basePostID) . ' ORDER BY language ASC';
+        $rows = $this->db->get_rows($sql);
+
+        return $this->return_instances($rows);
+    }
+
+    public function register_translation($basePostID, $translationPostID, $language)
+    {
+        $data = [
+            'basePostID'         => (int) $basePostID,
+            'translationPostID'  => (int) $translationPostID,
+            'language'           => $language,
+            'created'            => date('Y-m-d H:i:s'),
+        ];
+
+        $sql = 'INSERT INTO ' . $this->table . ' (basePostID, translationPostID, language, created) VALUES ('
+            . $this->db->pdb($data['basePostID']) . ', '
+            . $this->db->pdb($data['translationPostID']) . ', '
+            . $this->db->pdb($data['language']) . ', '
+            . $this->db->pdb($data['created']) . ')
+            ON DUPLICATE KEY UPDATE translationPostID=VALUES(translationPostID), created=VALUES(created)';
+
+        return $this->db->execute($sql);
+    }
+}
+

--- a/perch/addons/apps/perch_blog/lib/PerchBlog_Posts.class.php
+++ b/perch/addons/apps/perch_blog/lib/PerchBlog_Posts.class.php
@@ -220,7 +220,103 @@ class PerchBlog_Posts extends PerchAPI_Factory
             return $this->find($postID, true);
 		}
         return false;
-	}
+        }
+
+    public function create_translation(PerchBlog_Post $BasePost, $language, PerchBlog_PostTranslations $Translations, $base_post_id)
+    {
+        $language = trim($language);
+        if ($language === '') {
+            return false;
+        }
+
+        $base_details = $BasePost->get_details();
+        if (!is_array($base_details)) {
+            return false;
+        }
+
+        $data = $base_details;
+        unset($data['postID']);
+
+        $data['postSlug'] = $this->build_translation_slug($BasePost->postSlug(), $language);
+        $data['postStatus'] = 'Draft';
+        $data['postIsPublished'] = 0;
+
+        if (isset($data['postCommentCount'])) {
+            $data['postCommentCount'] = 0;
+        }
+
+        if (isset($data['postImportID'])) {
+            $data['postImportID'] = null;
+        }
+
+        if (isset($data['postLegacyURL'])) {
+            $data['postLegacyURL'] = null;
+        }
+
+        $dynamic_fields = [];
+        if (isset($data['postDynamicFields']) && $data['postDynamicFields'] != '') {
+            $dynamic_fields = PerchUtil::json_safe_decode($data['postDynamicFields'], true);
+            if (!is_array($dynamic_fields)) {
+                $dynamic_fields = [];
+            }
+        }
+
+        $dynamic_fields['_translate_language'] = $language;
+        $dynamic_fields['_translate_source_post'] = $BasePost->id();
+        $data['postDynamicFields'] = PerchUtil::json_safe_encode($dynamic_fields);
+
+        $NewPost = $this->create($data);
+        if (!$NewPost) {
+            return false;
+        }
+
+        $Template = $this->api->get('Template');
+        $Template->set('blog/'.$BasePost->postTemplate(), 'blog');
+        $NewPost->Template = $Template;
+        $NewPost->index($Template);
+
+        $Translations->register_translation($base_post_id, $NewPost->id(), $language);
+
+        return $NewPost;
+    }
+
+    private function build_translation_slug($base_slug, $language)
+    {
+        $segment = $this->clean_language_for_slug($language);
+        $slug = $base_slug.'-'.$segment;
+        $unique = $slug;
+        $i = 2;
+
+        while ($this->slug_exists($unique)) {
+            $unique = $slug.'-'.$i;
+            $i++;
+        }
+
+        return $unique;
+    }
+
+    private function clean_language_for_slug($language)
+    {
+        $segment = strtolower($language);
+        $segment = preg_replace('/[^a-z0-9\-]+/', '-', $segment);
+        $segment = trim($segment, '-');
+
+        if ($segment === '') {
+            $segment = strtolower(preg_replace('/[^a-z0-9]+/', '', $language));
+        }
+
+        if ($segment === '') {
+            $segment = 'translation';
+        }
+
+        return $segment;
+    }
+
+    private function slug_exists($slug)
+    {
+        $sql = 'SELECT COUNT(*) FROM '.$this->table.' WHERE postSlug='.$this->db->pdb($slug);
+        return ((int)$this->db->get_value($sql)) > 0;
+    }
 
 
 

--- a/perch/addons/apps/perch_blog/modes/_post_smartbar.php
+++ b/perch/addons/apps/perch_blog/modes/_post_smartbar.php
@@ -33,6 +33,14 @@
             ]);
 
         $Smartbar->add_item([
+                'active' => ($smartbar_selection=='translate'),
+                'link'   => $API->app_nav('perch_blog').'/translate/?id='.$Post->id(),
+                'title'  => 'Translate Post',
+                'icon'   => 'core/lang',
+                'priv'   => 'perch_blog.post.create',
+            ]);
+
+        $Smartbar->add_item([
                 'active'        => false,
                 'link'          => ($draft ? $Post->previewURL() : $Post->postURL()),
                 'title'         => ($draft ? 'Preview Draft' : 'View Post'),

--- a/perch/addons/apps/perch_blog/modes/_subnav.php
+++ b/perch/addons/apps/perch_blog/modes/_subnav.php
@@ -5,12 +5,13 @@
 
 	PerchUI::set_subnav([
 			[
-				'page' => [
-						'perch_blog',
-						'perch_blog/delete',
-						'perch_blog/edit',
-						'perch_blog/meta'
-				], 
+                                'page' => [
+                                                'perch_blog',
+                                                'perch_blog/delete',
+                                                'perch_blog/edit',
+                                                'perch_blog/meta',
+                                                'perch_blog/translate'
+                                ],
 				'label' => 'Posts'
 			],
 			[

--- a/perch/addons/apps/perch_blog/modes/post.translate.post.php
+++ b/perch/addons/apps/perch_blog/modes/post.translate.post.php
@@ -1,0 +1,78 @@
+<?php
+    echo $HTML->title_panel([
+        'heading' => sprintf($Lang->get('Translate %s Post'), ' &#8216;' . $HTML->encode($Post->postTitle()) . '&#8217;'),
+    ], $CurrentUser);
+
+    include(__DIR__.'/_post_smartbar.php');
+
+    $Alert->output();
+
+    if ($form_disabled) {
+        echo '<div class="inner">';
+        echo '<p>'.$Lang->get('No additional languages are available for this post.').'</p>';
+        echo '</div>';
+    } else {
+        echo $Form->form_start();
+
+        echo '<h2 class="divider"><div>'.$Lang->get('Languages').'</div></h2>';
+        echo '<div class="field-wrap">';
+        echo $Form->label('lang', $Lang->get('Translate post to'));
+        echo '<div class="form-entry">';
+        echo $Form->select('lang', $lang_options, $Form->get($form_defaults, 'lang'));
+        echo '</div>';
+        echo '</div>';
+
+        echo $HTML->submit_bar([
+            'button' => $Form->submit('btnsubmit', $Lang->get('Create translation'), 'button'),
+        ]);
+
+        echo $Form->form_end();
+    }
+
+    if (PerchUtil::count($existing_translations)) {
+        echo '<h2 class="divider"><div>'.$Lang->get('Existing translations').'</div></h2>';
+        echo '<div class="inner">';
+        echo '<table class="d">';
+        echo '<thead><tr>';
+        echo '<th>'.$Lang->get('Language').'</th>';
+        echo '<th>'.$Lang->get('Status').'</th>';
+        echo '<th class="action">'.$Lang->get('Actions').'</th>';
+        echo '</tr></thead>';
+        echo '<tbody>';
+
+        foreach ($existing_translations as $TranslationItem) {
+            if (!isset($TranslationItem['post']) || !$TranslationItem['post']) {
+                continue;
+            }
+
+            $TranslationPost = $TranslationItem['post'];
+            $language_label  = $TranslationItem['label'];
+
+            $status = $TranslationPost->postStatus();
+            if (strtotime($TranslationPost->postDateTime()) > time() && $status == 'Published') {
+                $status_label = $Lang->get('Will publish on date');
+            } else {
+                $status_label = $Lang->get($status);
+            }
+
+            $edit_label = $TranslationItem['is_base'] ? $Lang->get('Edit Post') : $Lang->get('Edit translation');
+            $edit_link  = $API->app_nav('perch_blog').'/edit/?id='.$TranslationPost->id();
+
+            $view_label = $TranslationPost->postStatus() == 'Draft' ? $Lang->get('Preview Draft') : $Lang->get('View Post');
+            $view_url   = $TranslationPost->postStatus() == 'Draft' ? $TranslationPost->previewURL() : $TranslationPost->postURL();
+
+            $actions = [];
+            $actions[] = '<a class="button button-small" href="'.$HTML->encode($edit_link).'">'.$HTML->encode($edit_label).'</a>';
+            $actions[] = '<a class="button button-small" href="'.$HTML->encode($view_url).'" target="_blank">'.$HTML->encode($view_label).'</a>';
+
+            echo '<tr>';
+            echo '<td>'.$HTML->encode($language_label).'</td>';
+            echo '<td>'.$HTML->encode($status_label).'</td>';
+            echo '<td class="action">'.implode(' ', $actions).'</td>';
+            echo '</tr>';
+        }
+
+        echo '</tbody>';
+        echo '</table>';
+        echo '</div>';
+    }

--- a/perch/addons/apps/perch_blog/modes/post.translate.pre.php
+++ b/perch/addons/apps/perch_blog/modes/post.translate.pre.php
@@ -1,0 +1,149 @@
+<?php
+    $Posts         = new PerchBlog_Posts($API);
+    $Blogs         = new PerchBlog_Blogs($API);
+    $Translations  = new PerchBlog_PostTranslations($API);
+    $LanguagesRepo = new PerchContent_Languages();
+
+    $blogs = $Blogs->all();
+
+    if (!$CurrentUser->has_priv('perch_blog.post.create')) {
+        PerchUtil::redirect($API->app_path());
+    }
+
+    $postID = (int) PerchUtil::get('id');
+    if (!$postID) {
+        PerchUtil::redirect($API->app_path());
+    }
+
+    $Post = $Posts->find($postID, true);
+    if (!$Post) {
+        PerchUtil::redirect($API->app_path());
+    }
+
+    $base_post_id = $Translations->find_base_id_for_post($Post->id());
+    if ($base_post_id && $base_post_id != $Post->id()) {
+        $BasePost = $Posts->find($base_post_id, true);
+        if (!$BasePost) {
+            $base_post_id = $Post->id();
+            $BasePost = $Post;
+        }
+    } else {
+        $base_post_id = $Post->id();
+        $BasePost = $Post;
+    }
+
+    $Blog = $Post->get_blog();
+    if (!$Blog && PerchUtil::count($blogs)) {
+        $Blog = $Blogs->first();
+    }
+
+    $smartbar_selection = 'translate';
+    $draft = ($Post->postStatus() == 'Draft');
+
+    $language_list = $LanguagesRepo->find_all();
+    $language_map  = [];
+    $lang_options  = [];
+    $available_language_values = [];
+    $existing_languages = [];
+    $existing_translations = [];
+
+    if (PerchUtil::count($language_list)) {
+        foreach ($language_list as $Language) {
+            $code  = $Language->lang();
+            $label = $Language->name();
+            if ($label == '') $label = $code;
+            $language_map[$code] = $label;
+        }
+    }
+
+    $existing_translations[] = [
+        'language' => null,
+        'label'    => $Lang->get('Base content'),
+        'post'     => $BasePost,
+        'is_base'  => true,
+    ];
+
+    $TranslationRows = $Translations->get_for_base($base_post_id);
+    if (PerchUtil::count($TranslationRows)) {
+        foreach ($TranslationRows as $Translation) {
+            $translation_post_id = (int) $Translation->translationPostID();
+
+            if ($translation_post_id === $base_post_id) {
+                continue;
+            }
+
+            $TranslationPost = $Posts->find($translation_post_id, true);
+            if (!$TranslationPost) {
+                $Translation->delete();
+                continue;
+            }
+
+            $code = $Translation->language();
+            $existing_languages[$code] = true;
+
+            $existing_translations[] = [
+                'language' => $code,
+                'label'    => isset($language_map[$code]) ? $language_map[$code] : $code,
+                'post'     => $TranslationPost,
+                'is_base'  => false,
+            ];
+        }
+    }
+
+    if (PerchUtil::count($language_map)) {
+        foreach ($language_map as $code => $label) {
+            if (!isset($existing_languages[$code])) {
+                $lang_options[] = [
+                    'label' => $label,
+                    'value' => $code,
+                ];
+                $available_language_values[] = $code;
+            }
+        }
+    }
+
+    $form_disabled = false;
+    if (!PerchUtil::count($language_map)) {
+        $form_disabled = true;
+        $Alert->set('notice', PerchLang::get('Enable page languages before creating translations.'));
+    } elseif (!PerchUtil::count($lang_options)) {
+        $form_disabled = true;
+        $Alert->set('info', PerchLang::get('Translations already exist for all configured languages.'));
+    }
+
+    $Form = $API->get('Form');
+    $Form->set_name('translate');
+
+    if (!$form_disabled) {
+        $Form->set_required([
+            'lang' => 'Required',
+        ]);
+    }
+
+    $form_defaults = [];
+
+    if ($Form->posted() && !$form_disabled) {
+        if ($Form->validate()) {
+            $data = $Form->receive(['lang']);
+            $selected_lang = trim($data['lang']);
+            $form_defaults['lang'] = $selected_lang;
+
+            if ($selected_lang === '' || !in_array($selected_lang, $available_language_values, true)) {
+                $Alert->set('error', $Lang->get('Please select a valid language.'));
+            } else {
+                $NewPost = $Posts->create_translation($BasePost, $selected_lang, $Translations, $base_post_id);
+                if ($NewPost) {
+                    PerchUtil::redirect($API->app_path().'/translate/?id='.$Post->id().'&created='.urlencode($selected_lang));
+                } else {
+                    $Alert->set('error', $Lang->get('Sorry, that translation could not be created.'));
+                }
+            }
+        } else {
+            $form_defaults['lang'] = $Form->get($form_defaults, 'lang');
+        }
+    }
+
+    if (PerchUtil::get('created')) {
+        $created_lang = PerchUtil::get('created');
+        $Alert->set('success', PerchLang::get('A %s translation has been created.', PerchUtil::html($created_lang)));
+    }

--- a/perch/addons/apps/perch_blog/translate/index.php
+++ b/perch/addons/apps/perch_blog/translate/index.php
@@ -1,0 +1,17 @@
+<?php
+    include('../../../../core/inc/api.php');
+
+    $API  = new PerchAPI(1.0, 'perch_blog');
+    $HTML = $API->get('HTML');
+    $Lang = $API->get('Lang');
+
+    $Perch->page_title = $Lang->get('Translate Post');
+
+    include('../modes/_subnav.php');
+    include('../modes/post.translate.pre.php');
+
+    include(PERCH_CORE . '/inc/top.php');
+
+    include('../modes/post.translate.post.php');
+
+    include(PERCH_CORE . '/inc/btm.php');

--- a/perch/core/apps/content/PerchContent_Regions.class.php
+++ b/perch/core/apps/content/PerchContent_Regions.class.php
@@ -71,27 +71,31 @@ class PerchContent_Regions extends PerchFactory
         $sort_dir = null;
 
 
-        $sql = 'SELECT';
+        $lang = trim($lang);
+        $suffix = ' - '.$lang;
 
-        $sql .= ' * FROM '.$this->table.' WHERE TRIM(regionKey) NOT REGEXP " - .{2}$" and pageID='.$this->db->pdb((int)$pageID);
+        $sql  = 'SELECT base.* FROM '.$this->table.' base';
+        $sql .= ' LEFT JOIN '.$this->table.' translated ON translated.pageID=base.pageID';
+        $sql .= ' AND translated.regionKey=CONCAT(base.regionKey, '.$this->db->pdb($suffix).')';
+        $sql .= ' WHERE base.pageID='.$this->db->pdb((int)$pageID);
+        $sql .= ' AND (base.language='.$this->db->pdb('*').' OR base.language='.$this->db->pdb('').' OR base.language IS NULL)';
 
         if (!$include_shared) {
-            $sql .= ' AND regionPage!='.$this->db->pdb('*');
+            $sql .= ' AND base.regionPage!='.$this->db->pdb('*');
         }
 
+        if ($new_only) {
+            $sql .= ' AND base.regionNew=1';
+        }
 
+        if ($template) {
+            $sql .= ' AND base.regionTemplate='.$this->db->pdb($template).' ';
+        }
 
-		if ($template) {
-			$sql .= ' AND regionTemplate='.$this->db->pdb($template).' ';
-		}
-
-
-
-
+        $sql .= ' AND translated.regionID IS NULL';
+        $sql .= ' ORDER BY base.regionOrder ASC';
 
         $rows = $this->db->get_rows($sql);
-
-
 
         return $this->return_instances($rows);
     }
@@ -104,7 +108,7 @@ class PerchContent_Regions extends PerchFactory
      * @return void
      * @author Drew McLellan
      */
-    public function get_for_page($pageID, $include_shared=true, $new_only=false, $template=false, PerchAPI_Paging $Paging = null)
+    public function get_for_page($pageID, $include_shared=true, $new_only=false, $template=false, PerchAPI_Paging $Paging = null, $language=false)
     {
         if ($this->_regions_preloaded) {
             if (isset($this->_region_cache[$pageID])) {
@@ -123,23 +127,31 @@ class PerchContent_Regions extends PerchFactory
         }
         
         $sql .= ' * FROM '.$this->table.' WHERE pageID='.$this->db->pdb((int)$pageID);
-        
+
         if (!$include_shared) {
             $sql .= ' AND regionPage!='.$this->db->pdb('*');
         }
 
-		if ($new_only) {
-			$sql .= ' AND regionNew=1 ';
-		}
-        
-		if ($template) {
-			$sql .= ' AND regionTemplate='.$this->db->pdb($template).' ';
-		}
+                if ($new_only) {
+                        $sql .= ' AND regionNew=1 ';
+                }
+
+                if ($template) {
+                        $sql .= ' AND regionTemplate='.$this->db->pdb($template).' ';
+                }
+
+        if ($language !== false && $language !== '') {
+            $language = trim($language);
+            $language_condition = 'language='.$this->db->pdb($language);
+            $language_condition .= ' OR ((language='.$this->db->pdb('*').' OR language='.$this->db->pdb('').' OR language IS NULL)';
+            $language_condition .= ' AND regionKey LIKE '.$this->db->pdb('% - '.$language).')';
+            $sql .= ' AND ('.$language_condition.')';
+        }
 
         if ($Paging && $Paging->enabled() && $sort_val) {
             $sql .= ' ORDER BY '.$sort_val.' '.$sort_dir;
         } else {
-            $sql .= ' ORDER BY regionOrder ASC';    
+            $sql .= ' ORDER BY regionOrder ASC';
         }
         
         if ($Paging && $Paging->enabled()) {

--- a/perch/core/apps/content/modes/page.edit.post.php
+++ b/perch/core/apps/content/modes/page.edit.post.php
@@ -28,9 +28,9 @@
             ]); 
          $Smartbar->add_item([
                 'title'  => 'Translate Page',
-                'link'   => '/core/apps/content/page/url/?id='.$Page->id(),
+                'link'   => '/core/apps/content/page/translate/?id='.$Page->id(),
                 'priv'   => 'content.pages.translate',
-                'icon'   => 'core/o-signs',
+                'icon'   => 'core/lang',
             ]);
 
             $Smartbar->add_item([

--- a/perch/core/apps/content/modes/page.post.php
+++ b/perch/core/apps/content/modes/page.post.php
@@ -42,7 +42,7 @@
                 'title'  => 'Translate Page',
                 'link'   => '/core/apps/content/page/translate/?id='.$Page->id(),
                 'priv'   => 'content.pages.translate',
-                'icon'   => 'core/o-signs',
+                'icon'   => 'core/lang',
             ]);
 
 			$Smartbar->add_item([

--- a/perch/core/apps/content/modes/page.pre.php
+++ b/perch/core/apps/content/modes/page.pre.php
@@ -15,9 +15,10 @@
           $tags = $Languages->find_all();
 
 
+    $lang = false;
     if (isset($_GET['lang']) && $_GET['lang'] != '') {
         $filter = 'lang';
-        $lang = $_GET['lang'];
+        $lang = trim($_GET['lang']);
 
     }
 
@@ -52,7 +53,7 @@
 	if ($Page->pagePath()=='*') {
         $regions = $Regions->get_shared($Paging);
     }else{
-        $regions = $Regions->get_for_page($Page->id(), $include_shared=false, $new_only=false, $template=false, $Paging);
+        $regions = $Regions->get_for_page($Page->id(), $include_shared=false, $new_only=false, $template=false, $Paging, $lang);
     }
 
 

--- a/perch/core/apps/content/modes/page.translate.post.php
+++ b/perch/core/apps/content/modes/page.translate.post.php
@@ -1,48 +1,78 @@
 <?php
+    echo $HTML->title_panel([
+        'heading' => sprintf(PerchLang::get('Translate %s Page'), ' &#8216;' . PerchUtil::html($Page->pageNavText()) . '&#8217; '),
+    ]);
 
-	    echo $HTML->title_panel([
-            'heading' => sprintf(PerchLang::get('Transalte %s Page'),' &#8216;' . PerchUtil::html($Page->pageNavText()) . '&#8217; ')
-            ]);
-?>
-    <form method="post" action="<?php echo PerchUtil::html($Form->action()); ?>" class="form-simple">
-<?php
+    $Smartbar = new PerchSmartbar($CurrentUser, $HTML, $Lang);
+    $Smartbar->add_item([
+        'title'  => 'Regions',
+        'link'   => '/core/apps/content/page/?id='.$Page->id(),
+        'icon'   => 'core/o-grid',
+    ]);
 
-                    echo '<h2 class="divider"><div>'.PerchLang::get('Languages').'</div></h2>';
-              ?>
-
-
-   <div class="field-wrap">
-            <?php echo $Form->label('lang', 'Transalte page to'); ?>
-            <div class="form-entry">
-            <?php
-                  $langs=[];
-                                              	if (PerchUtil::count($details)) {
-                                              			foreach($details as $row) {
-
-                                                               array_push($langs,$row->lang());
-
-                                              			}
-                                              			}
-
-                                   $opts = array();
-                                  if (!$vals) $vals = array();
-
-                                   if (PerchUtil::count($details)) {
-                                       foreach($details as $row) {
-
-                                           $opts[] = array('label'=>$row->lang(), 'value'=>$row->lang());
-                                       }
-                                   }
-              echo $Form->select('lang', $opts, $val);
-               echo $Form->checkbox_set('web_languages', 'Languages',  $opts,  $vals, $class='', $limit=false);
-
-            ?>
-            </div>
-        </div>
-       <?php
-
-    echo $HTML->submit_bar([
-        'button' =>$Form->submit('btnsubmit', 'Submit')
+    if ($Page->pagePath() != '*') {
+        $Smartbar->add_item([
+            'title'  => 'Details',
+            'link'   => '/core/apps/content/page/details/?id='.$Page->id(),
+            'priv'   => 'content.pages.attributes',
+            'icon'   => 'core/o-toggles',
         ]);
-?>
-    </form>
+
+        $Smartbar->add_item([
+            'title'  => 'Location',
+            'link'   => '/core/apps/content/page/url/?id='.$Page->id(),
+            'priv'   => 'content.pages.manage_urls',
+            'icon'   => 'core/o-signs',
+        ]);
+
+        $Smartbar->add_item([
+            'active' => true,
+            'title'  => 'Translate Page',
+            'link'   => '/core/apps/content/page/translate/?id='.$Page->id(),
+            'priv'   => 'content.pages.translate',
+            'icon'   => 'core/lang',
+        ]);
+
+        $Smartbar->add_item([
+            'title'         => 'View Page',
+            'link'          => rtrim($Settings->get('siteURL')->val(), '/').$Page->pagePath(),
+            'icon'          => 'core/document',
+            'position'      => 'end',
+            'new-tab'       => true,
+            'link-absolute' => true,
+        ]);
+
+        $Smartbar->add_item([
+            'title'    => 'Settings',
+            'link'     => '/core/apps/content/page/edit/?id='.$Page->id(),
+            'priv'     => 'content.pages.edit',
+            'icon'     => 'core/gear',
+            'position' => 'end',
+        ]);
+    }
+
+    echo $Smartbar->render();
+
+    $Alert->output();
+
+    if ($form_disabled) {
+        echo '<div class="inner">';
+        echo '<p>'.PerchLang::get('There are no additional languages available for this page.').'</p>';
+        echo '</div>';
+    } else {
+        echo $Form->form_start();
+
+        echo '<h2 class="divider"><div>'.PerchLang::get('Languages').'</div></h2>';
+        echo '<div class="field-wrap">';
+        echo $Form->label('lang', PerchLang::get('Translate page to'));
+        echo '<div class="form-entry">';
+        echo $Form->select('lang', $lang_options, $Form->get($form_defaults, 'lang'));
+        echo '</div>';
+        echo '</div>';
+
+        echo $HTML->submit_bar([
+            'button' => $Form->submit('btnsubmit', PerchLang::get('Create translation'), 'button'),
+        ]);
+
+        echo $Form->form_end();
+    }

--- a/perch/core/apps/content/modes/page.translate.pre.php
+++ b/perch/core/apps/content/modes/page.translate.pre.php
@@ -3,44 +3,142 @@
     $Lang   = $API->get('Lang');
     $HTML   = $API->get('HTML');
 
+    $Pages     = new PerchContent_Pages();
+    $Regions   = new PerchContent_Regions();
+    $Languages = new PerchContent_Languages();
+    $Page      = false;
 
-    $Pages = new PerchContent_Pages;
-    $Regions = new PerchContent_Regions;
-    $Page  = false;
+    $language_list = $Languages->find_all();
 
-        $Languages    = new PerchContent_Languages;
-          $details = $Languages->find_all();
+    if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+        $id   = (int) $_GET['id'];
+        $Page = $Pages->find($id);
+    }
 
+    if (!$Page || !is_object($Page)) {
+        PerchUtil::redirect(PERCH_LOGINPATH . '/core/apps/content/');
+    }
 
-        // Find the page
-        if (isset($_GET['id']) && is_numeric($_GET['id'])) {
-            $id = (int) $_GET['id'];
-            $Page = $Pages->find($id);
+    if (!$CurrentUser->has_priv('content.pages.translate')) {
+        PerchUtil::redirect(PERCH_LOGINPATH . '/core/apps/content/');
+    }
+
+    $Form = $API->get('Form');
+
+    $lang_options               = [];
+    $available_language_values  = [];
+    $existing_languages         = [];
+    $form_defaults              = [];
+    $selected_lang              = '';
+    $form_disabled              = false;
+
+    $language_codes = [];
+    if (PerchUtil::count($language_list)) {
+        foreach ($language_list as $Language) {
+            $language_codes[] = $Language->lang();
+        }
+    }
+
+    if (!PerchUtil::count($language_codes)) {
+        $form_disabled = true;
+        $Alert->set('notice', PerchLang::get('Enable page languages before creating translations.'));
+    }
+
+    if (!$form_disabled) {
+        $page_regions = $Regions->get_for_page($Page->id());
+        if (PerchUtil::count($page_regions)) {
+            foreach ($page_regions as $Region) {
+                $region_lang = $Region->language();
+                if ($region_lang && $region_lang !== '*' && $region_lang !== '') {
+                    $existing_languages[$region_lang] = true;
+                    continue;
+                }
+
+                if (preg_match('/^(.*) - ([A-Za-z0-9_\\-]+)$/', $Region->regionKey(), $matches)) {
+                    $base_key      = $matches[1];
+                    $possible_lang = $matches[2];
+
+                    if (in_array($possible_lang, $language_codes, true)) {
+                        $BaseRegion = $Regions->find_for_page_by_key($Page->id(), $base_key);
+                        if ($BaseRegion) {
+                            if ($region_lang === '*' || $region_lang === '' || $region_lang === false) {
+                                $Region->update(['language' => $possible_lang]);
+                                $region_lang = $possible_lang;
+                            }
+                            $existing_languages[$possible_lang] = true;
+                        }
+                    }
+                }
+            }
         }
 
-          $Form = new PerchForm('translatepage');
-  if ($Form->posted() ) {
-  $postvars = array('lang');
+        if (PerchUtil::count($language_list)) {
+            foreach ($language_list as $Language) {
+                $code  = $Language->lang();
+                $label = $Language->name();
+                if ($label == '') $label = $code;
 
+                if (!isset($existing_languages[$code])) {
+                    $lang_options[] = [
+                        'label' => $label,
+                        'value' => $code,
+                    ];
+                }
+            }
+        }
 
+        if (!PerchUtil::count($lang_options)) {
+            $form_disabled = true;
+            $Alert->set('info', PerchLang::get('Translations already exist for all configured languages.'));
+        } else {
+            foreach ($lang_options as $opt) {
+                $available_language_values[] = $opt['value'];
+            }
+        }
+    }
 
-      	$data = $Form->receive($postvars);
-      	//print_r($data);
-      	$lang=$data["lang"];
-      	$regions=$Regions->get_for_translation_page($lang,$id);
+    if (!$form_disabled) {
+        $Form->set_required([
+            'lang' => 'Required',
+        ]);
+    }
 
-      		foreach($regions as $region) {
-$newregionKey=$region->regionKey()." - ".$lang;
-                              // 	print_r($newregionKey);
-                               	$data=$region->to_array();
-                               	unset(	$data["regionID"]);
-                               	$data["regionKey"]=$newregionKey;
-                               	 	//print_r($data);
-                               	 $region->duplicate_region($data);
+    if ($Form->posted() && !$form_disabled && $Form->validate()) {
+        $data = $Form->receive(['lang']);
+        $selected_lang = trim($data['lang']);
+        $form_defaults['lang'] = $selected_lang;
 
-                               //	exit;
+        if ($selected_lang === '' || !in_array($selected_lang, $available_language_values, true)) {
+            $Alert->set('error', PerchLang::get('Please select a valid language.'));
+        } else {
+            $regions_to_duplicate = $Regions->get_for_translation_page($selected_lang, $Page->id());
+            if (!PerchUtil::count($regions_to_duplicate)) {
+                $Alert->set('info', PerchLang::get('All regions already have a %s translation.', PerchUtil::html($selected_lang)));
+            } else {
+                $created = false;
 
-	}
-    	       // PerchUtil::redirect(PERCH_LOGINPATH.'/core/apps/content/page/?id='.$id);
+                foreach ($regions_to_duplicate as $Region) {
+                    $data = $Region->to_array();
+                    unset($data['regionID']);
 
-  }
+                    $data['regionKey'] = $Region->regionKey() . ' - ' . $selected_lang;
+                    $data['language']  = $selected_lang;
+                    $data['regionNew'] = 1;
+
+                    $Region->duplicate_region($data);
+                    $created = true;
+                }
+
+                if ($created) {
+                    PerchUtil::redirect(PERCH_LOGINPATH . '/core/apps/content/page/translate/?id=' . $Page->id() . '&created=' . urlencode($selected_lang));
+                } else {
+                    $Alert->set('info', PerchLang::get('All regions already have a %s translation.', PerchUtil::html($selected_lang)));
+                }
+            }
+        }
+    }
+
+    if (PerchUtil::get('created')) {
+        $created_lang = PerchUtil::get('created');
+        $Alert->set('success', PerchLang::get('A %s translation has been created.', PerchUtil::html($created_lang)));
+    }

--- a/perch/core/apps/content/page/translate/index.php
+++ b/perch/core/apps/content/page/translate/index.php
@@ -6,7 +6,7 @@
     include(PERCH_CORE . '/inc/auth.php');
     
     
-    $Perch->page_title = PerchLang::get('Edit Page URL');
+    $Perch->page_title = PerchLang::get('Translate Page');
 
     $app_path = PERCH_CORE.'/apps/content';
     


### PR DESCRIPTION
## Summary
- document the end-to-end workflow for translating pages and blog posts in the README
- add blog post translation support with reusable translation records and draft duplication safeguards
- surface translation navigation in the blog admin UI, including a dashboard of existing translations with quick actions

## Testing
- php -l perch/addons/apps/perch_blog/lib/PerchBlog_PostTranslation.class.php
- php -l perch/addons/apps/perch_blog/lib/PerchBlog_PostTranslations.class.php
- php -l perch/addons/apps/perch_blog/lib/PerchBlog_Posts.class.php
- php -l perch/addons/apps/perch_blog/modes/_post_smartbar.php
- php -l perch/addons/apps/perch_blog/modes/_subnav.php
- php -l perch/addons/apps/perch_blog/modes/post.translate.pre.php
- php -l perch/addons/apps/perch_blog/modes/post.translate.post.php
- php -l perch/addons/apps/perch_blog/translate/index.php

------
https://chatgpt.com/codex/tasks/task_b_68d41e4b2c3c832495ddca858b77704c