### PR TITLE
Show variant stock on storefront product page

### DIFF
--- a/perch/addons/apps/perch_shop/templates/shop/products/product_view.html
+++ b/perch/addons/apps/perch_shop/templates/shop/products/product_view.html
@@ -40,13 +40,59 @@
 		<h1 class="h1-view"><perch:shop id="title" type="text" /></h1>
 		<img src="images/line.png" class="text-left mb-3" width="50" height="10">
 
-		<h2 class="font-weight-bold mt-4 mb-4"><perch:shop id="price" type="shop_currency_value" label="Price" divider-before="Pricing" size="s" min="0" step="any" /></h2>
+                <h2 class="font-weight-bold mt-4 mb-4"><perch:shop id="price" type="shop_currency_value" label="Price" divider-before="Pricing" size="s" min="0" step="any" /></h2>
 
+                <perch:if not-exists="has_variants">
+                        <p class="product-stock" data-stock-level="<perch:shop id="stock_level" escape="true" />">
+                                <perch:if exists="stock_level">
+                                        <perch:if id="stock_level" match="eq" value="0">
+                                                <span>Out of stock</span>
+                                        <perch:else />
+                                                <span>
+                                                        <perch:if id="stock_level" match="eq" value="INF">In stock<perch:else /><perch:shop id="stock_level" /> in stock</perch:if>
+                                                </span>
+                                        </perch:if>
+                                <perch:else />
+                                        <span>In stock</span>
+                                </perch:if>
+                        </p>
+                </perch:if>
 
-		<perch:form id="add_to_cart" app="perch_shop" action="/shop/cart.php">
-			<perch:input id="product" type="hidden" value="<perch:shop id="productID" type="hidden">">
-			<perch:input type="submit" value="Add to cart">
-		</perch:form>
+                <perch:form id="add_to_cart" app="perch_shop" action="/shop/cart.php">
+                        <perch:if exists="has_variants">
+                                <label class="product-variants__label" for="product">Choose an option</label>
+                                <select class="form-control mb-3" id="product" name="product" required>
+                                        <option value="" disabled selected>Select an option</option>
+                                        <perch:variants>
+                                                <perch:if exists="stock_level">
+                                                        <perch:if id="stock_level" match="eq" value="0">
+                                                        <perch:else />
+                                                                <option value="<perch:shop id="productID" escape="true" />" data-stock-level="<perch:shop id="stock_level" escape="true" />">
+                                                                        <perch:shop id="productVariantDesc" /> –
+                                                                        <perch:if id="stock_level" match="eq" value="INF">In stock<perch:else /><perch:shop id="stock_level" /> in stock</perch:if>
+                                                                </option>
+                                                        </perch:if>
+                                                <perch:else />
+                                                        <option value="<perch:shop id="productID" escape="true" />" data-stock-level="INF">
+                                                                <perch:shop id="productVariantDesc" /> – In stock
+                                                        </option>
+                                                </perch:if>
+                                        </perch:variants>
+                                </select>
+                                <perch:input class="btn btn-cart text-uppercase" type="submit" value="Add to cart" />
+                        <perch:else />
+                                <perch:input id="product" type="hidden" env-autofill="false" value='<perch:shop id="productID" type="hidden" env-autofill="false" />' />
+                                <perch:if exists="stock_level">
+                                        <perch:if id="stock_level" match="eq" value="0">
+                                                <button class="btn btn-secondary" type="button" disabled>Out of stock</button>
+                                        <perch:else />
+                                                <perch:input class="btn btn-cart text-uppercase" type="submit" value="Add to cart" />
+                                        </perch:if>
+                                <perch:else />
+                                        <perch:input class="btn btn-cart text-uppercase" type="submit" value="Add to cart" />
+                                </perch:if>
+                        </perch:if>
+                </perch:form>
 		<h4 class="mt-5">SKU <perch:shop id="sku" type="text" label="SKU" required="true" order="1"/></h4>
 
 	<h1 class="mt-5 h1-view">Description</h1>

--- a/perch/templates/products/package-builder/variant-options.html
+++ b/perch/templates/products/package-builder/variant-options.html
@@ -1,0 +1,76 @@
+<perch:before>
+<div class="package-builder-products">
+</perch:before>
+
+<form class="package-builder-products__item" method="post">
+    <input type="hidden" name="package_id" value="<perch:var id="package_id" escape="true" />" />
+    <input type="hidden" name="months" value="<perch:var id="months" escape="true" />" />
+    <input type="hidden" name="billing_type" value="<perch:var id="billing_type" escape="true" />" />
+    <input type="hidden" name="selections[<perch:var id="month" />][qty]" value="1" />
+
+    <header class="package-builder-products__header">
+        <h4 class="package-builder-products__title"><perch:shop id="title" type="text" /></h4>
+        <perch:if exists="description">
+            <div class="package-builder-products__description"><perch:shop id="description" type="textarea" markdown="true" /></div>
+        </perch:if>
+    </header>
+
+    <perch:if exists="has_variants">
+        <fieldset class="package-builder-products__variants">
+            <legend class="package-builder-products__variants-heading">Choose a dose</legend>
+            <ul class="package-builder-products__variant-list">
+                <perch:variants>
+                    <perch:if exists="stock_level">
+                        <perch:if id="stock_level" match="eq" value="0">
+                            <li class="package-builder-products__variant package-builder-products__variant--unavailable" data-stock-level="0">
+                                <span class="package-builder-products__variant-name"><perch:shop id="productVariantDesc" /></span>
+                                <span class="package-builder-products__variant-stock">Out of stock</span>
+                            </li>
+                        <perch:else />
+                            <li class="package-builder-products__variant" data-stock-level="<perch:shop id="stock_level" escape="true" />">
+                                <label>
+                                    <input type="radio" name="selections[<perch:var id="month" />][dose]" value="<perch:shop id="productID" />" />
+                                    <span class="package-builder-products__variant-name"><perch:shop id="productVariantDesc" /></span>
+                                    <span class="package-builder-products__variant-stock">
+                                        <perch:if id="stock_level" match="eq" value="INF">In stock<perch:else /><perch:shop id="stock_level" /> in stock</perch:if>
+                                    </span>
+                                </label>
+                            </li>
+                        </perch:if>
+                    <perch:else />
+                        <li class="package-builder-products__variant" data-stock-level="INF">
+                            <label>
+                                <input type="radio" name="selections[<perch:var id="month" />][dose]" value="<perch:shop id="productID" />" />
+                                <span class="package-builder-products__variant-name"><perch:shop id="productVariantDesc" /></span>
+                                <span class="package-builder-products__variant-stock">In stock</span>
+                            </label>
+                        </li>
+                    </perch:if>
+                </perch:variants>
+            </ul>
+        </fieldset>
+    <perch:else />
+        <input type="hidden" name="selections[<perch:var id="month" />][dose]" value="<perch:shop id="productID" />" />
+        <p class="package-builder-products__stock" data-stock-level="<perch:shop id="stock_level" escape="true" />">
+            <perch:if exists="stock_level">
+                <perch:if id="stock_level" match="eq" value="0">
+                    <span>Out of stock</span>
+                <perch:else />
+                    <span>
+                        <perch:if id="stock_level" match="eq" value="INF">In stock<perch:else /><perch:shop id="stock_level" /> in stock</perch:if>
+                    </span>
+                </perch:if>
+            <perch:else />
+                <span>In stock</span>
+            </perch:if>
+        </p>
+    </perch:if>
+
+    <footer class="package-builder-products__actions">
+        <button type="submit" name="selections[<perch:var id="month" />][product_id]" value="<perch:shop id="productID" />">Add to package</button>
+    </footer>
+</form>
+
+<perch:after>
+</div>
+</perch:after>

--- a/shop/package-builder.php
+++ b/shop/package-builder.php
@@ -190,7 +190,8 @@ if (isset($_GET['months'])) {
 
             perch_shop_products([
                 'category' => 'products/weight-loss',
-                'template' => 'products/package-builder/variant-options'
+                'template' => 'products/package-builder/variant-options',
+                'variants' => true,
             ]);
         } else {
             echo '<p class="muted">perch_shop_products() not available in this environment.</p>';

--- a/shop/products/index.php
+++ b/shop/products/index.php
@@ -5,7 +5,8 @@
 <?php
 
     perch_shop_product(perch_get("s"),[
-                                          'template' => 'products/product_view.html'
+                                          'template' => 'products/product_view.html',
+                                          'variants' => true,
                                       ]);
 
 ?>


### PR DESCRIPTION
## Summary
- request variant data when rendering the storefront product template
- surface per-variant stock counts in the product view and block purchases when a simple product is out of stock

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de72687ca483248192dbeec64df226