### PR TITLE
Handle missing order addresses when sending emails

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
@@ -329,10 +329,14 @@ class PerchShop_Order extends PerchShop_Base
         $Addresses = new PerchShop_Addresses($this->api);
 
         $ShippingAddr = $Addresses->find((int)$this->orderShippingAddress());
-        $Email->set_bulk($ShippingAddr->format_for_template('shipping'));
+        if ($ShippingAddr) {
+                $Email->set_bulk($ShippingAddr->format_for_template('shipping'));
+        }
 
-		$BillingAddr = $Addresses->find((int)$this->orderBillingAddress());
-        $Email->set_bulk($BillingAddr->format_for_template('billing'));
+        $BillingAddr = $Addresses->find((int)$this->orderBillingAddress());
+        if ($BillingAddr) {
+                $Email->set_bulk($BillingAddr->format_for_template('billing'));
+        }
 
         $OrderItems = new PerchShop_OrderItems($this->api);
         $items = $OrderItems->get_by('orderID', $this->id());


### PR DESCRIPTION
## Summary
- avoid calling format_for_template on a missing shipping or billing address when preparing order emails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e92712a50483248ef5aace59cd91da