### PR TITLE
Add option to exclude categories from event category lists

### DIFF
--- a/perch/addons/apps/perch_events/help.php
+++ b/perch/addons/apps/perch_events/help.php
@@ -1,0 +1,18 @@
+<p>The Events app enables you to list upcoming events, organise them into categories, and publish calendars or listings on your site.</p>
+
+<h2>Listing event categories</h2>
+<p>Use <code>perch_events_categories()</code> to output links to the categories you have created. The function accepts an optional array of settings so you can control which categories are returned.</p>
+
+<ul>
+    <li><code>template</code> &ndash; set an alternative template for each category.</li>
+    <li><code>include-empty</code> &ndash; pass <code>true</code> to show categories even when they have no upcoming events.</li>
+    <li><code>past-events</code> &ndash; pass <code>true</code> to base the counts on past events instead of future ones.</li>
+    <li><code>exclude</code> &ndash; supply a slug, title, ID, or an array of any combination of these values to omit specific categories from the output.</li>
+</ul>
+
+<p>Example:</p>
+<pre><code>&lt;?php perch_events_categories([
+    'exclude' => ['Promo', 'internal-updates']
+]); ?&gt;</code></pre>
+
+<p>In the example above, both the category titled “Promo” and the category whose slug is <code>internal-updates</code> will be removed from the rendered list.</p>

--- a/perch/addons/apps/perch_events/lib/PerchEvents_Categories.class.php
+++ b/perch/addons/apps/perch_events/lib/PerchEvents_Categories.class.php
@@ -67,11 +67,60 @@ class PerchEvents_Categories extends PerchAPI_Factory
 		$content = array();
 
         if (PerchUtil::count($cats)) {
-            foreach($cats as $Cat) $content[] = $Cat->to_array();    
+            foreach($cats as $Cat) $content[] = $Cat->to_array();
         }
-		
-		
-		if (isset($opts['filter']) && (isset($opts['value']) || is_array($opts['filter']))) {
+
+        if ($opts['exclude']) {
+            $exclude = $opts['exclude'];
+            if (!is_array($exclude)) $exclude = array($exclude);
+
+            $exclude_titles = array();
+            $exclude_slugs  = array();
+            $exclude_ids    = array();
+
+            $to_lower = function($value) {
+                $value = (string)$value;
+                if (function_exists('mb_strtolower')) {
+                    return mb_strtolower($value);
+                }
+                return strtolower($value);
+            };
+
+            foreach($exclude as $item) {
+                if (is_array($item)) continue;
+
+                if (is_numeric($item)) {
+                    $exclude_ids[] = (int)$item;
+                }
+
+                $item = trim((string)$item);
+
+                if ($item === '') continue;
+
+                $exclude_titles[] = $to_lower($item);
+                $exclude_slugs[]  = $to_lower(PerchUtil::urlify($item));
+            }
+
+            if (PerchUtil::count($content)) {
+                $filtered = array();
+                foreach($content as $cat_item) {
+                    $slug  = isset($cat_item['categorySlug']) ? $to_lower($cat_item['categorySlug']) : null;
+                    $title = isset($cat_item['categoryTitle']) ? $to_lower($cat_item['categoryTitle']) : null;
+                    $id    = isset($cat_item['categoryID']) ? (int)$cat_item['categoryID'] : null;
+
+                    if ($slug && in_array($slug, $exclude_slugs)) continue;
+                    if ($title && in_array($title, $exclude_titles)) continue;
+                    if ($id && in_array($id, $exclude_ids)) continue;
+
+                    $filtered[] = $cat_item;
+                }
+
+                $content = $filtered;
+            }
+        }
+
+
+        if (isset($opts['filter']) && (isset($opts['value']) || is_array($opts['filter']))) {
             if (PerchUtil::count($content)) {
                 $out = array();
 

--- a/perch/addons/apps/perch_events/runtime.php
+++ b/perch/addons/apps/perch_events/runtime.php
@@ -300,6 +300,7 @@
             'include-empty'        => false,
             'filter'               => false,
             'past-events'          => false,
+            'exclude'              => false,
         );
 
         if (is_array($opts)) {


### PR DESCRIPTION
## Summary
- add a new `exclude` option to the `perch_events_categories()` defaults so it can be used from templates
- filter the category collection by slug, title, or ID before rendering when exclusions are supplied
- document the new `exclude` setting in the Events app help page so developers know how to use it

## Testing
- php -l perch/addons/apps/perch_events/lib/PerchEvents_Categories.class.php
- php -l perch/addons/apps/perch_events/runtime.php

------
https://chatgpt.com/codex/tasks/task_b_68f10a6fd9c88324a21dbdd3888db6e7