### PR TITLE
Add category colors to event calendar markers

### DIFF
--- a/perch/addons/apps/perch_events/lib/PerchEvents_Event.class.php
+++ b/perch/addons/apps/perch_events/lib/PerchEvents_Event.class.php
@@ -75,23 +75,37 @@ class PerchEvents_Event extends PerchAPI_Base
         
         $Categories = new PerchEvents_Categories();
         $cats   = $Categories->get_for_event($this->id());
-        
+
         $out['category_slugs'] = '';
         $out['category_names'] = '';
-        
+        $out['category_colors'] = '';
+
         if (PerchUtil::count($cats)) {
             $slugs = array();
             $names = array();
+            $colors = array();
             foreach($cats as $Category) {
                 $slugs[] = $Category->categorySlug();
                 $names[] = $Category->categoryTitle();
-                
+
+                $category_data = $Category->to_array();
+
+                if (isset($category_data['color']) && $category_data['color'] !== '') {
+                    $colors[] = $category_data['color'];
+                    $out['category_color_'.$Category->categorySlug()] = $category_data['color'];
+                }
+
                 // for template
                 $out[$Category->categorySlug()] = true;
             }
-            
+
             $out['category_slugs'] = implode(' ', $slugs);
             $out['category_names'] = implode(', ', $names);
+
+            if (PerchUtil::count($colors)) {
+                $out['category_colors'] = implode(' ', $colors);
+                $out['category_color'] = reset($colors);
+            }
         }
 
         if (PerchUtil::count($template_ids) && in_array('eventURL', $template_ids)) {

--- a/perch/addons/apps/perch_events/templates/events/calendar/event-day.html
+++ b/perch/addons/apps/perch_events/templates/events/calendar/event-day.html
@@ -6,7 +6,12 @@
     <span class="value-title" title="<perch:events id="eventDateTime" format="c" />">
     <perch:events id="eventDateTime" format="g:i " />-<perch:events id="eventEndDateTime" format="g:i " />
 </span>
-    <span class="summary <perch:events id="category_slugs" />"><perch:events id="eventTitle" /></span>
+    <span class="summary <perch:events id="category_slugs" />">
+        <svg class="event-marker" viewBox="0 0 12 12" aria-hidden="true" role="img">
+            <circle cx="6" cy="6" r="5" fill="<perch:events id="category_color" default="currentColor" />" />
+        </svg>
+        <perch:events id="eventTitle" />
+    </span>
     </a>
 
 </div>

--- a/perch/addons/apps/perch_events/templates/events/category.html
+++ b/perch/addons/apps/perch_events/templates/events/category.html
@@ -1,3 +1,4 @@
 <h1><perch:events id="categoryTitle" type="text" /></h1>
 <perch:events id="image" type="image" label="Image" width="800" density="2" output="tag" />
 <perch:events id="desc" type="textarea" label="Description" editor="simplemde" markdown="true" size="s" />
+<perch:events id="color" type="color" label="Select color for category marker" />


### PR DESCRIPTION
## Summary
- add a color picker to event categories for marker styling
- expose category colors on event data for calendar templates
- render calendar event markers with the category color applied

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691b57fc3dac83248510271bf4059013)