### PR TITLE
Avoid logging hooks for orders export and localize PDO message

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_OrdersExport.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_OrdersExport.class.php
@@ -164,6 +164,16 @@ class PerchShop_OrdersExport
 		
 	}
 
+	public function log_user_actions()
+	{
+		return false;
+	}
+
+	public function ready_to_log_resources()
+	{
+		return false;
+	}
+
 
 
 

--- a/perch/addons/apps/perch_shop_orders/modes/export.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/export.pre.php
@@ -96,5 +96,5 @@
     } 
 
     if (PerchDB::$driver!='PDO') {
-    	$message = $HTML->failure_message('Export requires the PHP PDO library for connecting to your database.');
+    	$message = $HTML->failure_message($Lang->get('Export requires the PHP PDO library for connecting to your database.'));
     }


### PR DESCRIPTION
### Motivation
- Prevent a fatal error when form handling calls missing logging methods on the orders export object. 
- Ensure export flow does not attempt to log user actions or resources for a non-content export class. 
- Make the PDO requirement message translatable and consistent with the language system.

### Description
- Add no-op `log_user_actions()` and `ready_to_log_resources()` methods to `perch/addons/apps/perch_shop/lib/PerchShop_OrdersExport.class.php` so form hooks no longer call undefined methods. 
- Replace the hard-coded PDO failure string in `perch/addons/apps/perch_shop_orders/modes/export.pre.php` with `$Lang->get(...)` to enable localization. 
- Keep export behavior unchanged; the added methods return `false` and do not alter export logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695f8cc287d48324960fd8614dd64eea)