### PR TITLE
Support configurable post slug formats with placeholder tokens

### DIFF
--- a/perch/addons/apps/perch_blog/lib/PerchBlog_Posts.class.php
+++ b/perch/addons/apps/perch_blog/lib/PerchBlog_Posts.class.php
@@ -162,8 +162,36 @@ class PerchBlog_Posts extends PerchAPI_Factory
         if (!isset($data['postDateTime'])) $data['postDateTime'] = date('Y-m-d H:i:s');
 
         if (isset($data['postTitle']) && !isset($data['postSlug'])) {
-            $data['postSlug'] = PerchUtil::urlify(date('Y m d', strtotime($data['postDateTime'])). ' ' . $data['postTitle']);
+            $API  = new PerchAPI(1.0, 'perch_blog');
+            $Settings = $API->get('Settings');
+            $format = $Settings->get('perch_blog_slug_format')->val();
+            if (!$format) {
+                $format = 'Y-m-d-{postTitle}';
+            }
 
+            $timestamp = strtotime($data['postDateTime']);
+            $url_vars = $data;
+
+            $tokens = array();
+            $slug_format = $format;
+
+            if (preg_match_all('/{([A-Za-z0-9_\-]+)}/', $format, $matches)) {
+                foreach($matches[1] as $i => $match) {
+                    $key = '@@'.$i.'@@';
+                    $tokens[$key] = (isset($url_vars[$match]) ? $url_vars[$match] : '');
+                    $slug_format = str_replace($matches[0][$i], $key, $slug_format);
+                }
+            }
+
+            $slug = date($slug_format, $timestamp);
+
+            if (PerchUtil::count($tokens)) {
+                foreach($tokens as $key => $value) {
+                    $slug = str_replace($key, $value, $slug);
+                }
+            }
+
+            $data['postSlug'] = PerchUtil::urlify($slug);
         }
 
         if (isset($data['cat_ids']) && is_array($data['cat_ids'])) {


### PR DESCRIPTION
### Motivation
- Allow customizable post slug formats driven by site settings instead of the fixed date+title slug.
- Provide placeholder substitution for post fields so slugs can include arbitrary post metadata.

### Description
- Replace the previous slug generation in `PerchBlog_Posts::create` with a configurable format pulled from `Settings` via `PerchAPI` using the key `perch_blog_slug_format` and defaulting to `Y-m-d-{postTitle}` when unset.
- Implement placeholder parsing for tokens like `{postTitle}` by mapping them to values from the post data, applying PHP `date()` to the format using the post timestamp, then substituting placeholders before running `PerchUtil::urlify` on the final slug.
- Preserve existing behavior for categories and tags handling and ensure `postSlug` is set on new posts with the new formatting logic.

### Testing
- Ran the repository's automated test suite covering blog creation and slug generation; all tests passed.
- Executed automated integration tests for post creation with various `perch_blog_slug_format` values and placeholder combinations; tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6fbf7cbc083249a6c394050d9f51d)