### PR TITLE
Upgrade CKEditor integration to 4.24.0 LTS via CDN

### DIFF
--- a/perch/addons/plugins/editors/ckeditor/_config.json
+++ b/perch/addons/plugins/editors/ckeditor/_config.json
@@ -1,7 +1,7 @@
 {
 	"js": [
 		"PERCH_LOGINPATH/addons/plugins/editors/ckeditor/perch/env.js",
-		"PERCH_LOGINPATH/addons/plugins/editors/ckeditor/ckeditor-4/ckeditor.js",
+		"https://cdn.ckeditor.com/4.24.0-lts/standard-all/ckeditor.js",
 		"PERCH_LOGINPATH/addons/plugins/editors/ckeditor/perch/config.js"
 	],
 	"css": [

--- a/perch/addons/plugins/editors/ckeditor/perch/env.js
+++ b/perch/addons/plugins/editors/ckeditor/perch/env.js
@@ -1,2 +1,3 @@
-var CKEDITOR_BASEPATH = Perch.path + '/addons/plugins/editors/ckeditor/ckeditor-4/';
+// Use CKEditor LTS from CDN instead of the bundled legacy 4.8.0 build.
+var CKEDITOR_BASEPATH = 'https://cdn.ckeditor.com/4.24.0-lts/standard-all/';
 $('.ckeditor').removeClass('ckeditor').addClass('perch-ckeditor');


### PR DESCRIPTION
### Motivation
- Replace the bundled, outdated CKEditor 4.8.0 with a supported LTS build to improve security and editor behaviour while keeping integration risk minimal.
- Prefer a CDN-hosted LTS build to avoid shipping a large legacy vendor bundle and simplify future updates.

### Description
- Update `perch/addons/plugins/editors/ckeditor/_config.json` to load `https://cdn.ckeditor.com/4.24.0-lts/standard-all/ckeditor.js` instead of the local `ckeditor-4/ckeditor.js`.
- Update `perch/addons/plugins/editors/ckeditor/perch/env.js` to set `CKEDITOR_BASEPATH` to the CDN base URL and keep the existing `.ckeditor` → `.perch-ckeditor` initialization.
- Preserve existing Perch uploader integration and instance setup so no uploader routes or init logic were changed.

### Testing
- Ran `php -l perch/addons/plugins/editors/ckeditor/perch/uploader.php` and the lint check succeeded.
- Validated `perch/addons/plugins/editors/ckeditor/_config.json` by parsing it with Node (`JSON.parse`) and it parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cd3cbeb9b883248bc5f3c044e0c431)