### PR TITLE
Fix Perch blog draft preview author lookup and remove stray debug output

### DIFF
--- a/perch/addons/apps/perch_blog/lib/PerchBlog_Post.class.php
+++ b/perch/addons/apps/perch_blog/lib/PerchBlog_Post.class.php
@@ -31,7 +31,7 @@ class PerchBlog_Post extends PerchAPI_Base
                     $this->_load_author();
                 }
                 if (is_object($this->Author)) {
-                    return $this->Author->$field();
+                    return $this->Author->$method();
                 }
             }
 
@@ -219,8 +219,6 @@ $timestamp = strtotime($data['postDateTime']);
                 $out = array_merge($dynamic_fields, $out);
             }
         }
-        print_r($out);
-
         $out['postURL'] = $this->postURL();
         $out['postURLFull'] = $this->postURL(true);
 
@@ -493,4 +491,3 @@ $timestamp = strtotime($data['postDateTime']);
     }
 
 }
-


### PR DESCRIPTION
### Motivation
- Draft previews were causing HTTP 500 errors when template code accessed `author*` properties and the code attempted to dispatch using an undefined variable, and a stray debug dump could corrupt output during rendering.

### Description
- In `perch/addons/apps/perch_blog/lib/PerchBlog_Post.class.php` fixed `PerchBlog_Post::__call()` so `author*` lookups invoke the requested method name using `return $this->Author->$method();` instead of the undefined `$field` variable. 
- Removed a stray `print_r($out);` debug dump from `PerchBlog_Post::to_array()` that could inject unexpected output into responses.

### Testing
- Ran a PHP syntax check with `php -l perch/addons/apps/perch_blog/lib/PerchBlog_Post.class.php`, which reported no syntax errors and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ce3ee247008324845e03352497ffe2)