### PR TITLE
Add AI writing tools to CKEditor admin toolbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+perch/addons/plugins/editors/ckeditor/perch/ai/config.php

--- a/perch/addons/plugins/editors/ckeditor/perch/ai/ai.php
+++ b/perch/addons/plugins/editors/ckeditor/perch/ai/ai.php
@@ -1,0 +1,109 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+
+include __DIR__ . '/../../../../../core/inc/api.php';
+
+$Perch       = Perch::fetch();
+$Users       = new PerchUsers;
+$CurrentUser = $Users->get_current_user();
+
+if (!$CurrentUser || !$CurrentUser->logged_in()) {
+    http_response_code(403);
+    echo json_encode(['ok' => false, 'error' => 'Not authenticated']);
+    exit;
+}
+
+$config_path = __DIR__ . '/config.php';
+if (!file_exists($config_path)) {
+    http_response_code(500);
+    echo json_encode(['ok' => false, 'error' => 'Copy config.sample.php to config.php and set PERCH_AI_API_KEY.']);
+    exit;
+}
+require_once $config_path;
+
+if (!defined('PERCH_AI_API_KEY') || !PERCH_AI_API_KEY) {
+    http_response_code(500);
+    echo json_encode(['ok' => false, 'error' => 'PERCH_AI_API_KEY not set in config.php']);
+    exit;
+}
+
+$raw  = file_get_contents('php://input');
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'Invalid JSON']);
+    exit;
+}
+
+$action = isset($data['action']) ? $data['action'] : '';
+$html   = isset($data['html']) ? trim($data['html']) : '';
+
+if ($html === '') {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'Empty content']);
+    exit;
+}
+
+if (strlen($html) > 60000) {
+    http_response_code(413);
+    echo json_encode(['ok' => false, 'error' => 'Content too long']);
+    exit;
+}
+
+$prompts = [
+    'improve'   => 'You revise HTML fragments for clarity, grammar, and flow. Return ONLY the revised HTML fragment. Preserve the original language, meaning, and tag structure where reasonable. Do not wrap the output in code fences, explanations, or <html>/<body> tags.',
+    'summarize' => 'You summarize HTML fragments into a concise paragraph or short bullet list using HTML (<p> or <ul><li>). Return ONLY the summary HTML fragment. Do not wrap in code fences, explanations, or <html>/<body> tags.'
+];
+
+if (!isset($prompts[$action])) {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'Unknown action']);
+    exit;
+}
+
+$model = defined('PERCH_AI_MODEL') ? PERCH_AI_MODEL : 'claude-opus-4-7';
+
+$payload = [
+    'model'      => $model,
+    'max_tokens' => 2048,
+    'system'     => $prompts[$action],
+    'messages'   => [
+        ['role' => 'user', 'content' => $html]
+    ]
+];
+
+$ch = curl_init('https://api.anthropic.com/v1/messages');
+curl_setopt_array($ch, [
+    CURLOPT_POST           => true,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER     => [
+        'Content-Type: application/json',
+        'x-api-key: ' . PERCH_AI_API_KEY,
+        'anthropic-version: 2023-06-01'
+    ],
+    CURLOPT_POSTFIELDS => json_encode($payload),
+    CURLOPT_TIMEOUT    => 60
+]);
+$response = curl_exec($ch);
+$status   = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+$err      = curl_error($ch);
+curl_close($ch);
+
+if ($response === false) {
+    http_response_code(502);
+    echo json_encode(['ok' => false, 'error' => 'Upstream error: ' . $err]);
+    exit;
+}
+
+$parsed = json_decode($response, true);
+if ($status !== 200 || !isset($parsed['content'][0]['text'])) {
+    $msg = isset($parsed['error']['message']) ? $parsed['error']['message'] : 'Unexpected API response';
+    http_response_code(502);
+    echo json_encode(['ok' => false, 'error' => $msg]);
+    exit;
+}
+
+$out = trim($parsed['content'][0]['text']);
+$out = preg_replace('/^```(?:html)?\s*|\s*```$/m', '', $out);
+
+echo json_encode(['ok' => true, 'html' => $out]);

--- a/perch/addons/plugins/editors/ckeditor/perch/ai/config.sample.php
+++ b/perch/addons/plugins/editors/ckeditor/perch/ai/config.sample.php
@@ -1,0 +1,6 @@
+<?php
+// Copy this file to config.php (same directory) and fill in your Anthropic API key.
+// config.php is gitignored; config.sample.php is not.
+
+define('PERCH_AI_API_KEY', '');
+define('PERCH_AI_MODEL', 'claude-opus-4-7');

--- a/perch/addons/plugins/editors/ckeditor/perch/ai/plugin.js
+++ b/perch/addons/plugins/editors/ckeditor/perch/ai/plugin.js
@@ -1,0 +1,75 @@
+(function () {
+	var IMPROVE_ICON = 'data:image/svg+xml;base64,' + btoa('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="#333" d="M6 1l1.2 3.4L10.5 5.5 7.2 6.7 6 10.1 4.8 6.7 1.5 5.5 4.8 4.4z"/><path fill="#333" d="M12 8l.7 2 2 .7-2 .7-.7 2-.7-2-2-.7 2-.7z"/></svg>');
+	var SUMMARIZE_ICON = 'data:image/svg+xml;base64,' + btoa('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><rect fill="#333" x="2" y="3" width="12" height="2"/><rect fill="#333" x="2" y="7" width="12" height="2"/><rect fill="#333" x="2" y="11" width="8" height="2"/></svg>');
+
+	CKEDITOR.plugins.add('perchai', {
+		init: function (editor) {
+			var endpoint = (window.Perch && window.Perch.path ? window.Perch.path : '') +
+				'/addons/plugins/editors/ckeditor/perch/ai/ai.php';
+
+			var getSelectionHtml = function () {
+				var sel = editor.getSelection();
+				if (!sel) return '';
+				var ranges = sel.getRanges();
+				if (!ranges || !ranges.length || ranges[0].collapsed) return '';
+				var wrap = new CKEDITOR.dom.element('div');
+				wrap.append(ranges[0].cloneContents());
+				return wrap.getHtml();
+			};
+
+			var run = function (action, label) {
+				var selectionHtml = getSelectionHtml();
+				var replaceAll = !selectionHtml;
+				var payloadHtml = selectionHtml || editor.getData();
+
+				if (!payloadHtml || !payloadHtml.replace(/<[^>]+>/g, '').trim()) {
+					editor.showNotification('Nothing to ' + label.toLowerCase() + '.', 'warning');
+					return;
+				}
+
+				var notice = editor.showNotification(label + '…', 'progress', 0);
+
+				var xhr = new XMLHttpRequest();
+				xhr.open('POST', endpoint, true);
+				xhr.setRequestHeader('Content-Type', 'application/json');
+				xhr.onreadystatechange = function () {
+					if (xhr.readyState !== 4) return;
+					notice.hide();
+					var resp;
+					try { resp = JSON.parse(xhr.responseText); } catch (e) { resp = null; }
+
+					if (xhr.status !== 200 || !resp || !resp.ok) {
+						var msg = (resp && resp.error) ? resp.error : ('HTTP ' + xhr.status);
+						editor.showNotification('AI error: ' + msg, 'warning');
+						return;
+					}
+
+					if (replaceAll) {
+						editor.setData(resp.html);
+					} else {
+						editor.insertHtml(resp.html);
+					}
+					editor.showNotification(label + ' applied.', 'success');
+				};
+				xhr.send(JSON.stringify({ action: action, html: payloadHtml }));
+			};
+
+			editor.addCommand('perchaiImprove', { exec: function () { run('improve', 'Improving writing'); } });
+			editor.addCommand('perchaiSummarize', { exec: function () { run('summarize', 'Summarizing'); } });
+
+			editor.ui.addButton('PerchAIImprove', {
+				label: 'Improve writing (AI)',
+				command: 'perchaiImprove',
+				toolbar: 'insert,100',
+				icon: IMPROVE_ICON
+			});
+
+			editor.ui.addButton('PerchAISummarize', {
+				label: 'Summarize (AI)',
+				command: 'perchaiSummarize',
+				toolbar: 'insert,101',
+				icon: SUMMARIZE_ICON
+			});
+		}
+	});
+})();

--- a/perch/addons/plugins/editors/ckeditor/perch/config.js
+++ b/perch/addons/plugins/editors/ckeditor/perch/config.js
@@ -1,5 +1,8 @@
 $(function() {
 
+	CKEDITOR.plugins.addExternal('perchai', Perch.path + '/addons/plugins/editors/ckeditor/perch/ai/', 'plugin.js');
+	CKEDITOR.config.extraPlugins = (CKEDITOR.config.extraPlugins ? CKEDITOR.config.extraPlugins + ',' : '') + 'perchai';
+
 	var set_up_ckeditor = function() {
 
 		$('.ckeditor').removeClass('ckeditor').addClass('perch-ckeditor');


### PR DESCRIPTION
Introduces two inline buttons ("Improve writing" and "Summarize") in the Perch CKEditor admin, backed by a session-gated PHP proxy that calls the Anthropic Messages API. Acts on the current selection when present, or the full editor body otherwise.

- plugin.js registers the CKEditor 4 plugin and toolbar buttons
- ai.php authenticates via PerchUsers, loads the API key from a local config.php (gitignored), and forwards the request
- config.sample.php is the template admins copy to config.php
- config.js wires the plugin in via addExternal + extraPlugins so the existing standard-all toolbar picks up the new buttons
- .gitignore excludes the API-key config and .DS_Store